### PR TITLE
Navigate through the form's subgroups, in turn.

### DIFF
--- a/app/questiongroup/get.controller.js
+++ b/app/questiongroup/get.controller.js
@@ -3,16 +3,23 @@ const { getQuestionGroup, getAnswers } = require('../../common/data/assessmentAp
 
 const devAssessmentId = 'e69a61ff-7395-4a12-b434-b1aa6478aded'
 
-const displayQuestionGroup = async ({ params: { groupId }, tokens }, res) => {
+const displayQuestionGroup = async ({ params: { groupId, subgroup }, tokens }, res) => {
   try {
     const questionGroup = await grabQuestionGroup(groupId, tokens)
+    const subIndex = Number.parseInt(subgroup, 10)
+    if (subIndex === questionGroup.contents.length) {
+      return res.redirect('/questions')
+    }
+
     const { answers } = await grabAnswers(devAssessmentId, 'current', tokens)
 
     return res.render(`${__dirname}/index`, {
-      heading: questionGroup.contents[0].title,
+      heading: questionGroup.title,
+      subheading: questionGroup.contents[subIndex].title,
       groupId,
-      questions: questionGroup.contents[0].contents,
+      questions: questionGroup.contents[subIndex].contents,
       answers,
+      last: subIndex + 1 === questionGroup.contents.length,
     })
   } catch (error) {
     return res.render('app/error', { error })

--- a/app/questiongroup/index.njk
+++ b/app/questiongroup/index.njk
@@ -29,6 +29,10 @@
         {{ heading }}
     </h1>
 
+    <h3 class="govuk-heading-m">
+        {{ subheading }}
+    </h3>
+
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
 
@@ -71,10 +75,17 @@
 
                 {% endfor %}
 
-                {{ govukButton({
-                    text: 'Continue',
-                    classes: 'govuk-!-margin-bottom-3'
-                }) }}
+                {% if last %}
+                  {{ govukButton({
+                      text: 'Save',
+                      classes: 'govuk-!-margin-bottom-3'
+                  }) }}
+                {% else %}
+                  {{ govukButton({
+                      text: 'Continue',
+                      classes: 'govuk-!-margin-bottom-3'
+                  }) }}
+                {% endif %}
             </form>
         </div>
     </div>

--- a/app/questiongroup/post.controller.js
+++ b/app/questiongroup/post.controller.js
@@ -4,13 +4,14 @@ const { postAnswers } = require('../../common/data/assessmentApi')
 const devAssessmentId = 'e69a61ff-7395-4a12-b434-b1aa6478aded'
 const episodeId = '4511a3f6-7f51-4b96-b603-4e75eac0c839'
 
-const saveQuestionGroup = async ({ params: { groupId }, body, tokens }, res) => {
+const saveQuestionGroup = async ({ params: { groupId, subgroup }, body, tokens }, res) => {
   try {
     const answers = extractAnswers(body)
 
     await postAnswers(devAssessmentId, episodeId, answers, tokens)
 
-    return res.redirect(`/questionGroup/${groupId}`)
+    const subIndex = Number.parseInt(subgroup, 10)
+    return res.redirect(`/questionGroup/${groupId}/${subIndex + 1}`)
   } catch (error) {
     logger.error(`Could not save to assessment ${devAssessmentId}, episode ${episodeId}, error: ${error}`)
     return res.render('app/error', { error })

--- a/app/questions/get.controller.js
+++ b/app/questions/get.controller.js
@@ -10,7 +10,7 @@ const displayQuestionList = async ({ tokens }, res) => {
       .map(form => {
         return {
           ...form,
-          path: `/questionGroup/${form.groupId}`,
+          path: `/questionGroup/${form.groupId}/0`,
         }
       })
 

--- a/app/router.js
+++ b/app/router.js
@@ -33,9 +33,9 @@ module.exports = app => {
 
   app.get(`/questions`, displayQuestionList)
 
-  app.get(`/questiongroup/:groupId`, displayQuestionGroup)
+  app.get(`/questiongroup/:groupId/:subgroup`, displayQuestionGroup)
 
-  app.post(`/questiongroup/:groupId`, saveQuestionGroup)
+  app.post(`/questiongroup/:groupId/:subgroup`, saveQuestionGroup)
 
   app.get('*', (req, res) => res.render('app/error', { error: '404, Page Not Found' }))
 }


### PR DESCRIPTION
As the title. I've done this pretty quickly and feels a bit filthy, so if want to do it a different way or want to rip it out once the Show and Tell's done, that's fine

Once https://github.com/ministryofjustice/hmpps-assessments-api/pull/30 is merged down, the 'Layer 3' assessment will have two subgroups, and will show off this change.