### PR TITLE
Round-trip radio buttons

### DIFF
--- a/app/questiongroup/get.controller.js
+++ b/app/questiongroup/get.controller.js
@@ -12,13 +12,13 @@ const displayQuestionGroup = async ({ params: { groupId, subgroup }, tokens }, r
     }
 
     const { answers } = await grabAnswers(devAssessmentId, 'current', tokens)
+    const questions = annotateWithAnswers(questionGroup.contents[subIndex].contents, answers)
 
     return res.render(`${__dirname}/index`, {
       heading: questionGroup.title,
       subheading: questionGroup.contents[subIndex].title,
       groupId,
-      questions: questionGroup.contents[subIndex].contents,
-      answers,
+      questions,
       last: subIndex + 1 === questionGroup.contents.length,
     })
   } catch (error) {
@@ -42,6 +42,23 @@ const grabAnswers = (assessmentId, episodeId, tokens) => {
     logger.error(`Could not retrieve answers for assessment ${assessmentId} episode ${episodeId}, error: ${error}`)
     throw error
   }
+}
+
+const annotateWithAnswers = (questions, answers) => {
+  return questions.map(q => {
+    const answer = answers[q.questionId]
+    const answerValue = answer ? answer.freeTextAnswer : null
+    return Object.assign(q, {
+      answer: answerValue,
+      answerSchemas: annotateAnswerSchemas(q.answerSchemas, answerValue),
+    })
+  })
+}
+
+const annotateAnswerSchemas = (answerSchemas, answerValue) => {
+  if (answerValue === null) return answerSchemas
+
+  return answerSchemas.map(as => Object.assign(as, { checked: as.value === answerValue }))
 }
 
 module.exports = { displayQuestionGroup }

--- a/app/questiongroup/index.njk
+++ b/app/questiongroup/index.njk
@@ -46,7 +46,7 @@
                         {{ govukInput({
                             id: 'id-' + question.questionId,
                             name: 'id-' + question.questionId,
-                            value: answers[question.questionId].freeTextAnswer | encodeHtml | safe,
+                            value: question.answer | encodeHtml | safe,
                             label: {
                                 text: question.questionText,
                                 isPageHeading: false,
@@ -60,7 +60,7 @@
                         {{ govukTextarea({
                             id: 'id-' + question.questionId,
                             name: 'id-' + question.questionId,
-                            value: answers[question.questionId].freeTextAnswer | encodeHtml | safe,
+                            value: question.answer | encodeHtml | safe,
                             label: {
                                 text: question.questionText,
                                 isPageHeading: false,


### PR DESCRIPTION
Rather than passing the questions and the answer into the template separates, use the answers to annotate the question structure directly, adding an answer field and adding a checked field into the answerSchemas.

This simplifies the template slightly for text fields, and lets radio buttons roundtrip without any jiggery-pokery in the template. 