### PR TITLE
Render nested groups 

### DIFF
--- a/app/questionGroup/get.controller.js
+++ b/app/questionGroup/get.controller.js
@@ -59,6 +59,12 @@ const grabAnswers = (assessmentId, episodeId, tokens) => {
 
 const annotateWithAnswers = (questions, answers, body) => {
   return questions.map(q => {
+    if (q.type === 'group') {
+      // eslint-disable-next-line no-param-reassign
+      q.contents = annotateWithAnswers(q.contents, answers, body)
+      return q
+    }
+
     const answer = answers[q.questionId]
     const answerValue = body[`id-${q.questionId}`] || (answer ? answer.freeTextAnswer : null)
     return Object.assign(q, {

--- a/app/questionGroup/get.controller.js
+++ b/app/questionGroup/get.controller.js
@@ -84,6 +84,11 @@ const compileInlineConditionalQuestions = (questions, errors) => {
   // add in rendered conditional question strings to each answer when displayed inline
   // add appropriate classes to hide questions to be displayed out-of-line
   const compiledQuestions = questions.map(question => {
+    if (question.type === 'group') {
+      // eslint-disable-next-line no-param-reassign
+      question.contents = compileInlineConditionalQuestions(question.contents, errors)
+      return question
+    }
     const currentQuestion = question
     currentQuestion.answerSchemas = question.answerSchemas.map(schemaLine => {
       const updatedSchemaLine = schemaLine

--- a/common/templates/components/question/template.njk
+++ b/common/templates/components/question/template.njk
@@ -1,6 +1,7 @@
 {%- from "node_modules/govuk-frontend/govuk/components/input/macro.njk" import govukInput -%}
 {%- from "node_modules/govuk-frontend/govuk/components/textarea/macro.njk" import govukTextarea -%}
 {%- from "node_modules/govuk-frontend/govuk/components/radios/macro.njk" import govukRadios -%}
+{%- from "node_modules/govuk-frontend/govuk/components/checkboxes/macro.njk" import govukCheckboxes -%}
 {%- from "node_modules/govuk-frontend/govuk/components/select/macro.njk" import govukSelect -%}
 {%- from "node_modules/govuk-frontend/govuk/components/date-input/macro.njk" import govukDateInput -%}
 
@@ -61,6 +62,24 @@
     }) }}
   {% case 'radio' %}
     {{ govukRadios({
+      idPrefix: 'id-' + question.questionId,
+      name: 'id-' + question.questionId,
+      formGroup : {
+        classes: question.formClasses
+      },
+      attributes: question.attributes,
+      fieldset: {
+        legend: {
+          text: question.questionText,
+          classes: question.questionCode + ' govuk-label--m'
+        }
+      },
+      items: question.answerSchemas,
+      errorMessage: errorMessage,
+      isConditional: question.isConditional
+    }) }}
+  {% case 'checkbox' %}
+    {{ govukCheckboxes({
       idPrefix: 'id-' + question.questionId,
       name: 'id-' + question.questionId,
       formGroup : {

--- a/common/templates/components/question/template.njk
+++ b/common/templates/components/question/template.njk
@@ -8,6 +8,17 @@
 {% set questionAnswer = bodyAnswer or question.answer or '' %}
 {% set errorMessage = thisErrorMessage or errors['id-' + question.questionId] %}
 
+{% if question.type == 'group' %}
+  <h2 class="govuk-heading-m">
+    {{ question.title }}
+  </h2>
+
+
+  {% for question in question.contents %}
+      {{ renderQuestion(question, errors, bodyAnswers['id-' + question.questionId]) }}
+  {% endfor %}
+{% endif %}
+
 {% switch question.answerType %}
   {% case 'freetext' %}
     {{ govukInput({


### PR DESCRIPTION
See https://github.com/ministryofjustice/hmpps-assessments-api/pull/89

Extends the question renderer to handle groups within groups. Also drops in a first pass at rendering checkboxes, because the first set of nested groups we have (Risk of Serious Harm Screening, group 5) is absolutely riddled with them. 