### PR TITLE
Enable read only fields

### DIFF
--- a/app/questionGroup/get.controller.js
+++ b/app/questionGroup/get.controller.js
@@ -39,9 +39,18 @@ const displayQuestionGroup = async (
   }
 }
 
-const grabQuestionGroup = (groupId, tokens) => {
+const grabQuestionGroup = async (groupId, tokens) => {
   try {
-    return getQuestionGroup(groupId, tokens)
+    const questions = await getQuestionGroup(groupId, tokens)
+    const readOnlyToAttribute = q => {
+      if (q.readOnly) {
+        // eslint-disable-next-line no-param-reassign
+        q.attributes = { readonly: true, disabled: true, ...q.attributes }
+      }
+      q.contents?.forEach(c => readOnlyToAttribute(c))
+    }
+    questions.contents?.forEach(q => readOnlyToAttribute(q))
+    return questions
   } catch (error) {
     logger.error(`Could not retrieve question group for ${groupId}, error: ${error}`)
     throw error


### PR DESCRIPTION
This [API PR](https://github.com/ministryofjustice/hmpps-assessments-api/pull/94) adds a readonly to the questions. When true, those fields should be display only in the UI. 

This PR makes that change. For questions marked read only is builds readonly and disabled attributes, which get passed down to the govuk input widgets. I've mark disabled in addition to readonly because it's a very clear visual cue that it's working. What we actually want is some proper styling, but that's some distance beyond my comfort zone. 

![Screenshot from 2021-03-04 16-00-41](https://user-images.githubusercontent.com/555337/109992885-9c902b80-7d03-11eb-8c7d-029415b776ee.png)
