### PR TITLE
Arn 340 surface errors from backend

### DIFF
--- a/app/psrFromCourt/post.controller.js
+++ b/app/psrFromCourt/post.controller.js
@@ -13,7 +13,8 @@ const startPsrFromForm = ({ body, tokens }, res) => {
 
 const startPsr = async (courtCode, caseNumber, tokens, res) => {
   try {
-    const assessment = await assessmentSupervision({ courtCode, caseNumber }, tokens)
+    // eslint-disable-next-line no-unused-vars
+    const [ok, assessment] = await assessmentSupervision({ courtCode, caseNumber }, tokens)
 
     return res.redirect(`/${assessment.assessmentUuid}/questionGroup/pre_sentence_assessment/0/0`)
   } catch (error) {

--- a/app/questionGroup/post.controller.js
+++ b/app/questionGroup/post.controller.js
@@ -106,7 +106,12 @@ const saveQuestionGroup = async (req, res) => {
 
   try {
     const answers = extractAnswers(reqBody)
-    await postAnswers(assessmentId, 'current', answers, tokens)
+    // eslint-disable-next-line no-unused-vars
+    const [ok, episode] = await postAnswers(assessmentId, 'current', answers, tokens)
+
+    if (!ok) {
+      return displayQuestionGroup(req, res)
+    }
 
     return res.redirect(`/${assessmentId}/questiongroup/${res.locals.navigation.next.url}`)
   } catch (error) {

--- a/app/questionGroup/post.controller.js
+++ b/app/questionGroup/post.controller.js
@@ -106,10 +106,12 @@ const saveQuestionGroup = async (req, res) => {
 
   try {
     const answers = extractAnswers(reqBody)
-    // eslint-disable-next-line no-unused-vars
     const [ok, episode] = await postAnswers(assessmentId, 'current', answers, tokens)
 
     if (!ok) {
+      const [validationErrors, errorSummary] = formatValidationErrors(episode.errors)
+      req.errors = validationErrors
+      req.errorSummary = errorSummary
       return displayQuestionGroup(req, res)
     }
 
@@ -118,6 +120,20 @@ const saveQuestionGroup = async (req, res) => {
     logger.error(`Could not save to assessment ${assessmentId}, current episode, error: ${error}`)
     return res.render('app/error', { error })
   }
+}
+
+function formatValidationErrors(serverErrors) {
+  const errors = {}
+  const errorSummary = []
+  for (let i = 0; i < Object.entries(serverErrors).length; i += 1) {
+    const [id, msg] = Object.entries(serverErrors)[i]
+    errors[`id-${id}`] = { text: msg[0] }
+    errorSummary.push({
+      text: msg[msg.length === 2 ? 1 : 0],
+      href: `#id-${id}-error`,
+    })
+  }
+  return [errors, errorSummary]
 }
 
 function findDateAnswerKeys(postBody) {

--- a/app/questionGroup/post.controller.test.js
+++ b/app/questionGroup/post.controller.test.js
@@ -32,6 +32,10 @@ describe('post answers', () => {
   }
 
   it('should save the answers', async () => {
+    postAnswers.mockImplementation(() => {
+      return [true, {}]
+    })
+
     req.body = {
       'id-11111111-1111-1111-1111-111111111202': 'Hello',
       'id-11111111-1111-1111-1111-111111111201': 'there',
@@ -52,6 +56,9 @@ describe('post answers', () => {
   })
 
   it('should save the answers correctly when there are dates in the body', async () => {
+    postAnswers.mockImplementation(() => {
+      return [true, {}]
+    })
     req.body = {
       'id-11111111-1111-1111-1111-111111111205-day': '3',
       'id-11111111-1111-1111-1111-111111111205-month': '11',

--- a/common/data/assessmentApi.js
+++ b/common/data/assessmentApi.js
@@ -45,7 +45,7 @@ const postAnswers = (assessmentId, episodeId, answers, tokens) => {
 const getData = (path, tokens) => {
   logger.info(`Calling offenderAssessments API with GET: ${path}`)
 
-  return action(superagent.get(path), tokens)
+  return action(superagent.get(path), tokens).then(([_, body]) => body)
 }
 
 const postData = (path, tokens, data) => {
@@ -65,9 +65,15 @@ const action = async (agent, { authorisationToken }) => {
       .set('x-correlation-id', getCorrelationId())
       .timeout(timeout)
       .then(response => {
-        return response.body
+        return [true, response.body]
       })
   } catch (error) {
+    const { status, response } = error
+    if (status === 422) {
+      // unprocessable entity
+      return [false, response.body]
+    }
+
     return logError(error)
   }
 }


### PR DESCRIPTION
Tweak `postData` to return a ok/fail flag as well as the response body, so we can handle client-side recoverable failures separately from unrecoverable exceptions.

Pick this flag up in `saveQuestionGroup` and redisplay existing page with error annotations if the save wasn't successful. 