### PR TITLE
Fix issue with answers not being displayed for reference data

### DIFF
--- a/common/middleware/getQuestionGroup.js
+++ b/common/middleware/getQuestionGroup.js
@@ -57,7 +57,7 @@ const findParent = (questionGroups, section) => {
 
 const applyStaticReferenceData = async (questionResponse, tokens) => {
   const extractReferenceDataCategories = questionSchema => {
-    if (Array.isArray(questionSchema.contents)) {
+    if (questionSchema.type === 'group') {
       return questionSchema.contents.flatMap(extractReferenceDataCategories)
     }
     if (questionSchema.referenceDataCategory) {
@@ -92,11 +92,11 @@ const applyStaticReferenceData = async (questionResponse, tokens) => {
   )
 
   const applyReferenceData = questionSchema => {
-    if (Array.isArray(questionSchema.contents)) {
+    if (questionSchema.type === 'group') {
       return { ...questionSchema, contents: questionSchema.contents.map(applyReferenceData) }
     }
     if (questionSchema.referenceDataCategory) {
-      return { ...questionSchema, options: referenceData[questionSchema.referenceDataCategory] }
+      return { ...questionSchema, answerSchemas: referenceData[questionSchema.referenceDataCategory] }
     }
     return questionSchema
   }

--- a/common/middleware/getQuestionGroup.test.js
+++ b/common/middleware/getQuestionGroup.test.js
@@ -250,7 +250,7 @@ describe('getQuestionGroup middleware', () => {
         type: 'question',
         questionText: 'Test Question',
         referenceDataCategory: 'REFERENCE_DATA_CATEGORY_1',
-        options: [{ text: 'foo', value: 'bar' }],
+        answerSchemas: [{ text: 'foo', value: 'bar' }],
       })
     })
 

--- a/common/templates/components/question/template.njk
+++ b/common/templates/components/question/template.njk
@@ -117,7 +117,7 @@
             classes: question.questionCode + ' govuk-label--m'
           }
         },
-        items: question.options | default(question.answerSchemas),
+        items: question.answerSchemas,
         errorMessage: errorMessage,
         isConditional: question.isConditional,
         hint: {
@@ -138,7 +138,7 @@
             classes: question.questionCode + ' govuk-label--m'
           }
         },
-        items: question.options | default(question.answerSchemas),
+        items: question.answerSchemas,
         errorMessage: errorMessage,
         isConditional: question.isConditional,
         hint: {
@@ -158,7 +158,7 @@
           classes: question.questionCode + ' govuk-label--m'
         },
         attributes: question.attributes,
-        items: question.options | default(question.answerSchemas),
+        items: question.answerSchemas,
         errorMessage: errorMessage,
         isConditional: question.isConditional,
         hint: {

--- a/wiremock/responses/assessmentEpisodes.json
+++ b/wiremock/responses/assessmentEpisodes.json
@@ -28,6 +28,7 @@
     "5af89c42-ffa2-4a29-8975-ab0eb8770a1c": ["Kent"],
     "10c93cf5-cc0c-404b-b6e4-da176db45527": ["Greg Ginn"],
     "54b03faa-efc0-49ef-9add-7581dca17d70": ["103 - Aggravated assaults"],
-    "91c83565-91dc-4876-97d7-f186ce04584c": ["00 - Aggravated assaults"]
+    "91c83565-91dc-4876-97d7-f186ce04584c": ["00 - Aggravated assaults"],
+    "2b93527c-a545-4e41-9fb4-98ee127af393": ["100", "110"]
   }
 }


### PR DESCRIPTION
### Context
Currently answers are not being displayed for reference data fields, I believe this is down to myself misunderstanding the role of `answerSchema` on a `questionSchema`

### Steps to reproduce
- Select a "Source of Information"
- Save
- Reload the page

**expected:** the selected options are presented back to the user
**actual:** the selected options are not presented back to the user

### Intent
- Remove use of options field in favour of `answerSchema`
- Revert template to solely use `answerSchema`
- Update WireMock stubs to have answers for Sources of Information
- Update check for whether a `questionSchema` is part of a group to be consistent with the rest of the codebase