### PR TITLE
Arn 370 ROSH Previous Convictions Questions

### DIFF
--- a/app/questionGroup/get.controller.js
+++ b/app/questionGroup/get.controller.js
@@ -157,6 +157,9 @@ const compileInlineConditionalQuestions = (questions, errors) => {
     .map(question => {
       // add css to hide questions to be displayed out of line
       const questionObject = question
+      if (!questionObject.questionText) {
+        questionObject.formClasses = 'govuk-input--packTogether'
+      }
       if (questionObject.conditional) {
         questionObject.formClasses =
           'govuk-radios__conditional govuk-radios__conditional--noIndent govuk-radios__conditional--hidden'

--- a/common/assets/sass/application.scss
+++ b/common/assets/sass/application.scss
@@ -155,6 +155,9 @@ p {
   border-left: none;
 }
 
+.govuk-input--packTogether {
+  margin-top: -30px;
+}
 
 .moj-task-list__task-completed {
   background-color: govuk-colour("green");

--- a/common/templates/components/question/template.njk
+++ b/common/templates/components/question/template.njk
@@ -64,6 +64,25 @@
     {% case 'presentation: link' %}
       <div class="body-link__container"><a href="{{ linkTarget }}" class="govuk-link body-link">{{ question.questionText }}</a></div>
 
+    {% case 'noinput' %}
+      {{ govukInput({
+        id: 'id-' + question.questionId,
+        name: 'id-' + question.questionId,
+        formGroup : {
+          classes: formClass or question.formClasses
+        },
+        classes: 'moj-hidden',
+        attributes: question.attributes,
+        label: {
+          text: question.questionText,
+          isPageHeading: false,
+          classes: question.questionCode + ' govuk-label--m'
+        },
+        hint: {
+          text: question.helpText
+        },
+        errorMessage: errorMessage
+      }) }}
     {% case 'freetext' %}
       {{ govukInput({
         id: 'id-' + question.questionId,
@@ -82,7 +101,6 @@
           text: question.helpText
         },
         errorMessage: errorMessage
-
       }) }}
     {% case 'textarea' %}
       {{ govukTextarea({


### PR DESCRIPTION
Layout and rendering tweaks. They'll apply generally, but prompted by the ROSH Previous convictions section. 

* 'noinput' input type. For rendering questions which have business rules attached, but don't have any input of they're own - "Has the individual been convicted of any of the following offences ...", for example. 


See related assessment-api PR https://github.com/ministryofjustice/hmpps-assessments-api/pull/136 