### PR TITLE
Arn 361 fetch filtered reference data

### DIFF
--- a/app/questionGroup/get.controller.js
+++ b/app/questionGroup/get.controller.js
@@ -117,9 +117,13 @@ const compileInlineConditionalQuestions = (questions, errors) => {
           let conditionalQuestionString =
             '{% from "./common/templates/components/question/macro.njk" import renderQuestion %} \n'
 
-          conditionalQuestionString += `{{ renderQuestion(${JSON.stringify(
-            conditionalQuestions[subjectId],
-          )},'','',${thisError}) }}`
+          const conditionalQuestion = conditionalQuestions[subjectId]
+          const attributesString = JSON.stringify(conditionalQuestion.attributes)
+
+          conditionalQuestionString += `{{ renderQuestion(${JSON.stringify({
+            ...conditionalQuestion,
+            attributes: attributesString,
+          })},'','',${thisError}) }}`
 
           updatedSchemaLine.conditional = {
             html: nunjucks.renderString(conditionalQuestionString).replace(/(\r\n|\n|\r)\s+/gm, ''),

--- a/app/questionGroup/get.controller.js
+++ b/app/questionGroup/get.controller.js
@@ -11,7 +11,11 @@ const displayQuestionGroup = async (
     const { questionGroup } = res.locals
     const subIndex = Number.parseInt(subgroup, 10)
 
-    const { answers } = await grabAnswers(assessmentId, 'current', tokens)
+    const { answers, episodeUuid } = await grabAnswers(assessmentId, 'current', tokens)
+
+    res.locals.assessmentUuid = assessmentId
+    res.locals.episodeUuid = episodeUuid
+
     let questions = annotateWithAnswers(questionGroup.contents, answers, body)
     questions = compileInlineConditionalQuestions(questions, errors)
 

--- a/app/questionGroup/get.controller.test.js
+++ b/app/questionGroup/get.controller.test.js
@@ -82,4 +82,17 @@ describe('display question group and answers', () => {
     await displayQuestionGroup(req, res)
     expect(res.render).toHaveBeenCalledWith(`app/error`, { error: theError })
   })
+
+  it('adds assessment information to the template for use by client-side javascript', async () => {
+    getAnswers.mockReturnValueOnce({
+      answers: {},
+      episodeUuid: 'test-episode-id',
+    })
+    await displayQuestionGroup(req, res)
+
+    expect(res.locals).toMatchObject({
+      assessmentUuid: 'test-assessment-id',
+      episodeUuid: 'test-episode-id',
+    })
+  })
 })

--- a/app/questionGroup/index.njk
+++ b/app/questionGroup/index.njk
@@ -59,4 +59,12 @@
             </form>
         </div>
     </div>
+
+    <script src="/javascripts/filtered-reference-data.js"></script>
+    <script>
+        document.onload = addFilteredReferenceDataListeners(
+            {{ assessmentUuid | dump | safe }},
+            {{ episodeUuid | dump | safe }}
+        );
+    </script>
 {% endblock %}

--- a/app/questionGroup/index.njk
+++ b/app/questionGroup/index.njk
@@ -52,7 +52,7 @@
                     {{ govukButton({
                         text: 'Back to assessment progress',
                         classes: 'govuk-button--secondary',
-                        href: "/" + assessmentId + "/questiongroup/" + groupId + "/summary"
+                        href: '/' + assessmentId + '/questiongroup/' + groupId + '/summary'
                     }) }}
                 </div>
 
@@ -63,8 +63,8 @@
     <script src="/javascripts/filtered-reference-data.js"></script>
     <script>
         document.onload = addFilteredReferenceDataListeners(
-            {{ assessmentUuid | dump | safe }},
-            {{ episodeUuid | dump | safe }}
+            '{{ assessmentUuid | safe }}',
+            '{{ episodeUuid | safe }}'
         );
     </script>
 {% endblock %}

--- a/app/referenceData/post.controller.js
+++ b/app/referenceData/post.controller.js
@@ -1,0 +1,27 @@
+const { getFilteredReferenceData } = require('../../common/data/hmppsAssessmentApi')
+
+const fetchFilteredReferenceData = async (req, res) => {
+  try {
+    const {
+      params: { assessmentUuid, episodeUuid },
+      body,
+      tokens,
+    } = req
+    const { questionUuid, targetValues } = body
+
+    // eslint-disable-next-line no-unused-vars
+    const [_, response] = await getFilteredReferenceData(
+      assessmentUuid,
+      episodeUuid,
+      questionUuid,
+      targetValues,
+      tokens,
+    )
+
+    return res.json(response.map(({ description, code }) => ({ text: description, value: code })))
+  } catch (error) {
+    return res.status(error.response.status).send()
+  }
+}
+
+module.exports = { fetchFilteredReferenceData }

--- a/app/referenceData/post.controller.js
+++ b/app/referenceData/post.controller.js
@@ -3,20 +3,14 @@ const { getFilteredReferenceData } = require('../../common/data/hmppsAssessmentA
 const fetchFilteredReferenceData = async (req, res) => {
   try {
     const {
-      params: { assessmentUuid, episodeUuid },
+      params: { assessmentId, episodeId },
       body,
       tokens,
     } = req
     const { questionUuid, targetValues } = body
 
     // eslint-disable-next-line no-unused-vars
-    const [_, response] = await getFilteredReferenceData(
-      assessmentUuid,
-      episodeUuid,
-      questionUuid,
-      targetValues,
-      tokens,
-    )
+    const [_, response] = await getFilteredReferenceData(assessmentId, episodeId, questionUuid, targetValues, tokens)
 
     return res.json(response.map(({ description, code }) => ({ text: description, value: code })))
   } catch (error) {

--- a/app/referenceData/post.controller.js
+++ b/app/referenceData/post.controller.js
@@ -14,7 +14,7 @@ const fetchFilteredReferenceData = async (req, res) => {
 
     return res.json(response.map(({ description, code }) => ({ text: description, value: code })))
   } catch (error) {
-    return res.status(error.response.status).send()
+    return res.status(error.response?.status || 500).send()
   }
 }
 

--- a/app/referenceData/post.controller.test.js
+++ b/app/referenceData/post.controller.test.js
@@ -1,0 +1,95 @@
+const { fetchFilteredReferenceData } = require('./post.controller')
+const { getFilteredReferenceData } = require('../../common/data/hmppsAssessmentApi')
+
+jest.mock('../../common/data/hmppsAssessmentApi')
+
+let req
+const tokens = { authorisationToken: 'mytoken' }
+
+beforeEach(() => {
+  req = {
+    params: {
+      assessmentId: 'test-assessment-id',
+      groupId: '22222222-2222-2222-2222-222222222204',
+      subgroup: 0,
+    },
+    tokens,
+    body: {},
+  }
+})
+
+describe('fetch filtered reference data', () => {
+  const send = jest.fn()
+  const res = {
+    json: jest.fn(),
+    status: jest.fn(() => ({ send })),
+    send,
+  }
+
+  it('should fetch filtered reference data from the assessments service', async () => {
+    const responseBody = [
+      { code: 'first', description: 'First' },
+      { code: 'second', description: 'Second' },
+    ]
+
+    getFilteredReferenceData.mockImplementation(() => {
+      return [true, responseBody]
+    })
+
+    req.body = {
+      questionUuid: 'bbbbbbbb-cccc-dddd-eeee-ffffffffffff',
+      targetValues: {
+        'cccccccc-dddd-eeee-ffff-gggggggggggg': 'some-value',
+      },
+    }
+
+    req.params = {
+      assessmentUuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      episodeUuid: 'eeeeeeee-dddd-cccc-bbbb-aaaaaaaaaaaa',
+    }
+
+    await fetchFilteredReferenceData(req, res)
+
+    expect(getFilteredReferenceData).toHaveBeenCalledWith(
+      'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      'eeeeeeee-dddd-cccc-bbbb-aaaaaaaaaaaa',
+      'bbbbbbbb-cccc-dddd-eeee-ffffffffffff',
+      { 'cccccccc-dddd-eeee-ffff-gggggggggggg': 'some-value' },
+      tokens,
+    )
+
+    expect(res.json).toHaveBeenCalledWith([
+      { value: 'first', text: 'First' },
+      { value: 'second', text: 'Second' },
+    ])
+  })
+
+  it('passes response status down to the client when requests fail', async () => {
+    /* eslint-disable */
+    getFilteredReferenceData.mockImplementation(() =>
+      Promise.reject({
+        response: {
+          status: 418,
+        },
+      }),
+    )
+    /* eslint-enable */
+
+    req.body = {
+      questionUuid: 'bbbbbbbb-cccc-dddd-eeee-ffffffffffff',
+      targetValues: {
+        'cccccccc-dddd-eeee-ffff-gggggggggggg': 'some-value',
+      },
+    }
+
+    req.params = {
+      assessmentUuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      episodeUuid: 'eeeeeeee-dddd-cccc-bbbb-aaaaaaaaaaaa',
+    }
+
+    await fetchFilteredReferenceData(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(418)
+    expect(res.send).toHaveBeenCalled()
+  })
+})

--- a/app/referenceData/post.controller.test.js
+++ b/app/referenceData/post.controller.test.js
@@ -9,9 +9,8 @@ const tokens = { authorisationToken: 'mytoken' }
 beforeEach(() => {
   req = {
     params: {
-      assessmentId: 'test-assessment-id',
-      groupId: '22222222-2222-2222-2222-222222222204',
-      subgroup: 0,
+      assessmentId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      episodeId: 'eeeeeeee-dddd-cccc-bbbb-aaaaaaaaaaaa',
     },
     tokens,
     body: {},
@@ -41,11 +40,6 @@ describe('fetch filtered reference data', () => {
       targetValues: {
         'cccccccc-dddd-eeee-ffff-gggggggggggg': 'some-value',
       },
-    }
-
-    req.params = {
-      assessmentUuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
-      episodeUuid: 'eeeeeeee-dddd-cccc-bbbb-aaaaaaaaaaaa',
     }
 
     await fetchFilteredReferenceData(req, res)
@@ -80,11 +74,6 @@ describe('fetch filtered reference data', () => {
       targetValues: {
         'cccccccc-dddd-eeee-ffff-gggggggggggg': 'some-value',
       },
-    }
-
-    req.params = {
-      assessmentUuid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
-      episodeUuid: 'eeeeeeee-dddd-cccc-bbbb-aaaaaaaaaaaa',
     }
 
     await fetchFilteredReferenceData(req, res)

--- a/app/router.js
+++ b/app/router.js
@@ -16,6 +16,7 @@ const { displayQuestionGroup } = require('./questionGroup/get.controller')
 const { displayOverview } = require('./summary/get.controller')
 const { completeAssessment } = require('./summary/post.controller')
 const { saveQuestionGroup, assembleDates, questionGroupValidationRules } = require('./questionGroup/post.controller')
+const { fetchFilteredReferenceData } = require('./referenceData/post.controller')
 const { psrFromCourt } = require('./psrFromCourt/get.controller')
 const { startPsrFromCourt, startPsrFromForm } = require('./psrFromCourt/post.controller')
 
@@ -71,6 +72,8 @@ module.exports = app => {
     validate,
     saveQuestionGroup,
   )
+
+  app.post(`/:assessmentUuid/episode/:episodeUuid/referencedata/filtered`, fetchFilteredReferenceData)
 
   app.post('/:assessmentId/questiongroup/:groupId/summary', getOffenderDetails, completeAssessment)
 

--- a/app/router.js
+++ b/app/router.js
@@ -73,7 +73,7 @@ module.exports = app => {
     saveQuestionGroup,
   )
 
-  app.post(`/:assessmentUuid/episode/:episodeUuid/referencedata/filtered`, fetchFilteredReferenceData)
+  app.post(`/:assessmentId/episode/:episodeId/referencedata/filtered`, fetchFilteredReferenceData)
 
   app.post('/:assessmentId/questiongroup/:groupId/summary', getOffenderDetails, completeAssessment)
 

--- a/common/assets/javascripts/filtered-reference-data.js
+++ b/common/assets/javascripts/filtered-reference-data.js
@@ -1,0 +1,87 @@
+/* eslint-disable */
+function addFilteredReferenceDataListeners(assessmentUuid, episodeUuid) {
+  var state = {}
+  var elementsWithTargets = document.querySelectorAll('[data-reference-data-target]')
+
+  function targetHasValues(state) {
+    var keys = Object.keys(state)
+    for (var i = 0; i < keys.length; i++) {
+      if (state[keys[i]] === null) {
+        return false
+      }
+    }
+    return true
+  }
+
+  function clearOptions(multipleChoiceElement) {
+    while (multipleChoiceElement.options.length > 0) {
+      multipleChoiceElement.remove(0)
+    }
+  }
+
+  function updateOptions(multipleChoiceElement, newOptions) {
+    clearOptions(multipleChoiceElement)
+
+    for (var i = 0; i < newOptions.length; i++) {
+      var option = newOptions[i]
+
+      var optionElement = document.createElement('option')
+      optionElement.text = option.text
+      optionElement.value = option.value
+
+      multipleChoiceElement.add(optionElement)
+    }
+  }
+
+  function fetchReferenceData(state, multipleChoiceElement, callback) {
+    if (targetHasValues(state)) {
+      var req = new XMLHttpRequest()
+      req.open('POST', '/' + assessmentUuid + '/episode/' + episodeUuid + '/referencedata/filtered')
+      req.setRequestHeader('Content-Type', 'application/json;charset=UTF-8')
+      req.send(JSON.stringify(state))
+
+      req.onload = function() {
+        if (this.status !== 200) {
+          return clearOptions(multipleChoiceElement)
+        }
+        callback(JSON.parse(this.responseText))
+      }
+
+      req.onerror = function() {
+        clearOptions(multipleChoiceElement)
+      }
+    }
+  }
+
+  function addListenerToTarget(questionUuid, multipleChoiceElement, state) {
+    target.addEventListener('change', function(event) {
+      state.targetValues[questionUuid] = event.target.value
+
+      fetchReferenceData(state, multipleChoiceElement, function(newOptions) {
+        updateOptions(multipleChoiceElement, newOptions)
+      })
+    })
+  }
+
+  for (var i = 0; i < elementsWithTargets.length; i++) {
+    var element = elementsWithTargets[i]
+    var questionUuid = element.dataset.questionUuid
+    var targetId = element.dataset.referenceDataTarget
+
+    state[questionUuid] = { questionUuid: questionUuid, targetValues: {} }
+    state[questionUuid].targetValues[targetId] = null
+
+    var targets = document.querySelectorAll('[data-question-uuid="' + targetId + '"]')
+
+    for (var j = 0; j < targets.length; j++) {
+      var target = targets[j]
+      var targetId = target.dataset.questionUuid
+
+      state[questionUuid].targetValues[targetId] = target.value
+      fetchReferenceData(state[questionUuid], element, function(newOptions) {
+        updateOptions(element, newOptions)
+      })
+      addListenerToTarget(targetId, element, state[questionUuid])
+    }
+  }
+}

--- a/common/data/hmppsAssessmentApi.js
+++ b/common/data/hmppsAssessmentApi.js
@@ -47,6 +47,17 @@ const postAnswers = (assessmentId, episodeId, answers, tokens) => {
   return postData(path, tokens, answers)
 }
 
+const getFilteredReferenceData = (assessmentId, episodeId, questionUuid, parentList, tokens) => {
+  const path = `${url}/referencedata/filtered`
+  const requestBody = {
+    assessmentUuid: assessmentId,
+    episodeUuid: episodeId,
+    fieldName: questionUuid,
+    parentList,
+  }
+  return postData(path, tokens, requestBody)
+}
+
 const getData = (path, tokens) => {
   logger.info(`Calling hmppsAssessments API with GET: ${path}`)
 
@@ -119,4 +130,5 @@ module.exports = {
   postAnswers,
   getQuestionGroupSummary,
   postCompleteAssessment,
+  getFilteredReferenceData,
 }

--- a/common/middleware/getQuestionGroup.js
+++ b/common/middleware/getQuestionGroup.js
@@ -121,6 +121,21 @@ module.exports = async ({ params: { groupId, subgroup = 0, page = 0 }, tokens },
       q.contents?.forEach(c => readOnlyToAttribute(c))
     }
     thisQuestionGroup.contents?.forEach(q => readOnlyToAttribute(q))
+    thisQuestionGroup.contents = thisQuestionGroup.contents?.map(question => {
+      const attributes = {
+        ...question.attributes,
+        'data-question-uuid': question.questionId,
+      }
+
+      if (question.referenceDataTarget) {
+        attributes['data-reference-data-target'] = question.referenceDataTarget
+      }
+
+      return {
+        ...question,
+        attributes,
+      }
+    })
     res.locals.questionGroup = processReplacements(thisQuestionGroup, res.locals.offenderDetails)
 
     const navigation = {

--- a/integration-tests/integration/questions/filtered-reference-data.spec.js
+++ b/integration-tests/integration/questions/filtered-reference-data.spec.js
@@ -1,0 +1,87 @@
+const FilteredReferenceDataTestPage = require('../../pages/questions/filteredReferenceDataTestPage')
+
+context('Test filtered reference data fields', () => {
+  before(() => {
+    cy.task('stubAssessmentApi')
+  })
+
+  it('Displays questions', () => {
+    const questionsPage = FilteredReferenceDataTestPage.goTo()
+
+    questionsPage
+      .questions()
+      .eq(0)
+      .should('include.text', 'Assessor')
+
+    questionsPage
+      .questions()
+      .eq(1)
+      .should('include.text', 'Assessor Office')
+  })
+
+  it('Populates reference data fields on page load', () => {
+    const questionsPage = FilteredReferenceDataTestPage.goTo()
+
+    questionsPage
+      .questions()
+      .contains('div', 'Assessor Office')
+      .find('option')
+      .then(options => {
+        const listOfOptions = [...options].map(o => o.text)
+        expect(listOfOptions).to.deep.eq(['First Office', 'Second Office'])
+      })
+  })
+
+  it('updates reference data fields when the target field is updated', () => {
+    const questionsPage = FilteredReferenceDataTestPage.goTo()
+
+    cy.intercept(
+      'POST',
+      '/e69a61ff-7395-4a12-b434-b1aa6478aded/episode/4511a3f6-7f51-4b96-b603-4e75eac0c839/referencedata/filtered',
+    ).as('update')
+
+    questionsPage
+      .questions()
+      .contains('div', 'Assessor')
+      .find('select')
+      .select('second')
+
+    cy.wait('@update')
+      .its('response.statusCode')
+      .should('eq', 200)
+
+    questionsPage
+      .questions()
+      .contains('div', 'Assessor Office')
+      .find('option')
+      .then(options => {
+        const listOfOptions = [...options].map(o => o.text)
+        expect(listOfOptions).to.deep.eq(['Third Office', 'Fourth Office'])
+      })
+  })
+
+  it('fails gracefully when the call for reference data fails', () => {
+    const questionsPage = FilteredReferenceDataTestPage.goTo()
+
+    cy.intercept(
+      'POST',
+      '/e69a61ff-7395-4a12-b434-b1aa6478aded/episode/4511a3f6-7f51-4b96-b603-4e75eac0c839/referencedata/filtered',
+    ).as('update')
+
+    questionsPage
+      .questions()
+      .contains('div', 'Assessor')
+      .find('select')
+      .select('fail')
+
+    cy.wait('@update')
+      .its('response.statusCode')
+      .should('eq', 500)
+
+    questionsPage
+      .questions()
+      .contains('div', 'Assessor Office')
+      .find('option')
+      .should('not.exist')
+  })
+})

--- a/integration-tests/pages/questions/filteredReferenceDataTestPage.js
+++ b/integration-tests/pages/questions/filteredReferenceDataTestPage.js
@@ -1,0 +1,24 @@
+const page = require('../page')
+const AssessmentsPage = require('../assessments/assessmentsPage')
+
+const filteredReferenceDataPage = () =>
+  page('Test filtered reference data', {
+    questions: () => cy.get('.govuk-form-group'),
+    errorSummary: () => cy.get('.govuk-error-summary'),
+    save: () => cy.get('button').contains('Save and continue'),
+  })
+
+export default {
+  verifyOnPage: filteredReferenceDataPage,
+  goTo: (assessmentNumber = 0) => {
+    AssessmentsPage.goTo()
+      .assessments()
+      .find('a')
+      .eq(assessmentNumber)
+      .click()
+      .get('.moj-task-list__task-name')
+      .contains('Assessor')
+      .click()
+    return filteredReferenceDataPage()
+  },
+}

--- a/integration-tests/pages/questions/questionsPage1.js
+++ b/integration-tests/pages/questions/questionsPage1.js
@@ -17,6 +17,7 @@ export default {
       .eq(assessmentNumber)
       .click()
       .get('.moj-task-list__task-name')
+      .first()
       .click()
     return questionsPage1()
   },

--- a/integration-tests/plugins/index.js
+++ b/integration-tests/plugins/index.js
@@ -9,6 +9,7 @@ const {
   stubOffenderDetails,
   stubQuestionSummaries,
 } = require('../../wiremock/assessmentApi')
+const { stubReferenceData } = require('../../wiremock/referenceData')
 const oauthApi = require('../../wiremock/oauth')
 
 module.exports = on => {
@@ -29,6 +30,7 @@ module.exports = on => {
         stubEpisodes(),
         stubOffenderDetails(),
         stubQuestionSummaries(),
+        stubReferenceData(),
       ]),
     stubAuth: () => Promise.all([oauthApi.stubGetToken()]),
   })

--- a/wiremock/referenceData.js
+++ b/wiremock/referenceData.js
@@ -29,8 +29,8 @@ const stubDynamicReferenceData = field => {
       headers: {
         'Content-Type': 'application/json;charset=UTF-8',
       },
-      status: 200,
-      jsonBody: filteredReferenceData[field].response,
+      status: filteredReferenceData[field].response.status,
+      jsonBody: filteredReferenceData[field].response.body,
     },
   })
 }
@@ -39,6 +39,7 @@ const stubReferenceData = async () => {
   await stubStaticReferenceData('SOURCES_OF_INFORMATION')
   await stubDynamicReferenceData('ASSESSOR_OFFICE--FIRST')
   await stubDynamicReferenceData('ASSESSOR_OFFICE--SECOND')
+  await stubDynamicReferenceData('ASSESSOR_OFFICE--FAIL')
 }
 
 module.exports = {

--- a/wiremock/referenceData.js
+++ b/wiremock/referenceData.js
@@ -1,5 +1,6 @@
 const { stubFor } = require('./wiremock')
 const referenceData = require('./responses/referenceData.json')
+const filteredReferenceData = require('./responses/filteredReferenceData.json')
 
 const stubStaticReferenceData = category => {
   stubFor({
@@ -17,8 +18,27 @@ const stubStaticReferenceData = category => {
   })
 }
 
+const stubDynamicReferenceData = field => {
+  stubFor({
+    request: {
+      method: 'POST',
+      urlPattern: '/referencedata/filtered',
+      bodyPatterns: filteredReferenceData[field].request,
+    },
+    response: {
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      status: 200,
+      jsonBody: filteredReferenceData[field].response,
+    },
+  })
+}
+
 const stubReferenceData = async () => {
   await stubStaticReferenceData('SOURCES_OF_INFORMATION')
+  await stubDynamicReferenceData('ASSESSOR_OFFICE--FIRST')
+  await stubDynamicReferenceData('ASSESSOR_OFFICE--SECOND')
 }
 
 module.exports = {

--- a/wiremock/responses/filteredReferenceData.json
+++ b/wiremock/responses/filteredReferenceData.json
@@ -1,0 +1,40 @@
+{
+  "ASSESSOR_OFFICE--FIRST": {
+    "request": [
+      {
+        "equalToJson": "{\"assessmentUuid\":\"e69a61ff-7395-4a12-b434-b1aa6478aded\",\"episodeUuid\":\"4511a3f6-7f51-4b96-b603-4e75eac0c839\",\"fieldName\":\"11111111-1111-1111-1111-111111111203\",\"parentList\":{\"11111111-1111-1111-1111-111111111202\":\"first\"}}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ],
+    "response": [
+      {
+        "code": "100",
+        "description": "First Office"
+      },
+      {
+        "code": "101",
+        "description": "Second office"
+      }
+    ]
+  },
+  "ASSESSOR_OFFICE--SECOND": {
+    "request": [
+      {
+        "equalToJson": "{\"assessmentUuid\":\"e69a61ff-7395-4a12-b434-b1aa6478aded\",\"episodeUuid\":\"4511a3f6-7f51-4b96-b603-4e75eac0c839\",\"fieldName\":\"11111111-1111-1111-1111-111111111203\",\"parentList\":{\"11111111-1111-1111-1111-111111111202\":\"second\"}}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ],
+    "response": [
+      {
+        "code": "102",
+        "description": "Third Office"
+      },
+      {
+        "code": "103",
+        "description": "Fourth office"
+      }
+    ]
+  }
+}

--- a/wiremock/responses/filteredReferenceData.json
+++ b/wiremock/responses/filteredReferenceData.json
@@ -7,16 +7,19 @@
         "ignoreExtraElements": true
       }
     ],
-    "response": [
-      {
-        "code": "100",
-        "description": "First Office"
-      },
-      {
-        "code": "101",
-        "description": "Second office"
-      }
-    ]
+    "response": {
+      "status": 200,
+      "body": [
+        {
+          "code": "100",
+          "description": "First Office"
+        },
+        {
+          "code": "101",
+          "description": "Second Office"
+        }
+      ]
+    }
   },
   "ASSESSOR_OFFICE--SECOND": {
     "request": [
@@ -26,15 +29,31 @@
         "ignoreExtraElements": true
       }
     ],
-    "response": [
+    "response": {
+      "status": 200,
+      "body": [
+        {
+          "code": "102",
+          "description": "Third Office"
+        },
+        {
+          "code": "103",
+          "description": "Fourth Office"
+        }
+      ]
+    }
+  },
+  "ASSESSOR_OFFICE--FAIL": {
+    "request": [
       {
-        "code": "102",
-        "description": "Third Office"
-      },
-      {
-        "code": "103",
-        "description": "Fourth office"
+        "equalToJson": "{\"assessmentUuid\":\"e69a61ff-7395-4a12-b434-b1aa6478aded\",\"episodeUuid\":\"4511a3f6-7f51-4b96-b603-4e75eac0c839\",\"fieldName\":\"11111111-1111-1111-1111-111111111203\",\"parentList\":{\"11111111-1111-1111-1111-111111111202\":\"fail\"}}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
       }
-    ]
+    ],
+    "response": {
+      "status": 500,
+      "body": {}
+    }
   }
 }

--- a/wiremock/responses/questionGroupSummary.json
+++ b/wiremock/responses/questionGroupSummary.json
@@ -172,6 +172,18 @@
             "title": "Sample page 1"
           }
         ]
+      },
+      {
+        "groupId": "71b4c413-83f2-48af-a330-0c5d5a4b6e34",
+        "groupCode": "2_filtered_reference_data",
+        "title": "Sample questions",
+        "contents": [
+          {
+            "groupId": "22222222-2222-2222-2222-222222222201",
+            "groupCode": "assessor",
+            "title": "Assessor"
+          }
+        ]
       }
     ]
   }

--- a/wiremock/responses/questionGroups.json
+++ b/wiremock/responses/questionGroups.json
@@ -589,6 +589,12 @@
                     "answerSchemaCode": "SR0.0.0.0",
                     "value": "second",
                     "text": "Second"
+                  },
+                  {
+                    "answerSchemaUuid": "44444444-4444-4444-4444-444444444403",
+                    "answerSchemaCode": "SR0.0.0.0",
+                    "value": "fail",
+                    "text": "Will fail"
                   }
                 ],
                 "answer": null,

--- a/wiremock/responses/questionGroups.json
+++ b/wiremock/responses/questionGroups.json
@@ -554,6 +554,62 @@
             ]
           }
         ]
+      },
+      {
+        "type": "group",
+        "groupId": "22222222-2222-2222-2222-222222222204",
+        "groupCode": "test_filtered_reference_data",
+        "title": "Test filtered reference data",
+        "displayOrder": "2",
+        "mandatory": "yes",
+        "contents": [
+          {
+            "type": "group",
+            "groupId": "22222222-2222-2222-2222-222222222205",
+            "groupCode": "test_filtered_reference_data",
+            "title": "Test filtered reference data",
+            "contents": [
+              {
+                "type": "question",
+                "questionId": "11111111-1111-1111-1111-111111111202",
+                "questionCode": "assessor",
+                "answerType": "dropdown",
+                "questionText": "Assessor",
+                "displayOrder": "1",
+                "mandatory": "yes",
+                "answerSchemas": [
+                  {
+                    "answerSchemaUuid": "44444444-4444-4444-4444-444444444401",
+                    "answerSchemaCode": "SR0.0.0.0",
+                    "value": "first",
+                    "text": "First"
+                  },
+                  {
+                    "answerSchemaUuid": "44444444-4444-4444-4444-444444444402",
+                    "answerSchemaCode": "SR0.0.0.0",
+                    "value": "second",
+                    "text": "Second"
+                  }
+                ],
+                "answer": null,
+                "validation": "{\"mandatory\":{\"errorMessage\":\"Enter and assessor\",\"errorSummary\":\"You must have an assessor\"}}"
+              },
+              {
+                "type": "question",
+                "questionId": "11111111-1111-1111-1111-111111111203",
+                "questionCode": "assessor_office",
+                "answerType": "dropdown",
+                "questionText": "Assessor Office",
+                "displayOrder": "1",
+                "mandatory": "yes",
+                "answerSchemas": [],
+                "answer": null,
+                "referenceDataTarget": "11111111-1111-1111-1111-111111111202",
+                "validation": "{\"mandatory\":{\"errorMessage\":\"Enter and assessor office\",\"errorSummary\":\"You must have an assessor office\"}}"
+              }
+            ]
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
### Context

This PR is to update the frontend to support filtered reference data

### Intent

- Add WireMock stubs
- Update the client to pull filtered reference data from the assessment API
- Create an API endpoint for use by the client
- Create client-side javascript to fetch filtered reference data

### Considerations

- (fixed with the [PR](https://github.com/ministryofjustice/hmpps-assessments-api/pull/142)) This code relies on the `parentFields` supplying UUIDs instead of field names