### PR TITLE
Add support for radio groups with dynamic ref data

### DIFF
--- a/common/middleware/getQuestionGroup.js
+++ b/common/middleware/getQuestionGroup.js
@@ -125,6 +125,7 @@ module.exports = async ({ params: { groupId, subgroup = 0, page = 0 }, tokens },
       const attributes = {
         ...question.attributes,
         'data-question-uuid': question.questionId,
+        'data-question-type': question.answerType,
       }
 
       if (question.referenceDataTarget) {

--- a/common/middleware/getQuestionGroup.test.js
+++ b/common/middleware/getQuestionGroup.test.js
@@ -353,6 +353,7 @@ describe('getQuestionGroup middleware', () => {
               contents: [
                 {
                   type: 'question',
+                  answerType: 'text',
                   questionId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
                   questionText: 'Test Question',
                   referenceDataTarget: 'eeeeeeee-dddd-cccc-bbbb-aaaaaaaaaaaa',
@@ -373,6 +374,18 @@ describe('getQuestionGroup middleware', () => {
         type: 'question',
         questionText: 'Test Question',
         attributes: { 'data-question-uuid': 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' },
+      })
+    })
+
+    it('adds a data attribute with the question type', async () => {
+      getQuestionGroup.mockResolvedValue(questionSchema)
+
+      await getQuestion(req, res, next)
+
+      expect(res.locals.questionGroup.contents[0]).toMatchObject({
+        type: 'question',
+        questionText: 'Test Question',
+        attributes: { 'data-question-type': 'text' },
       })
     })
 

--- a/integration-tests/integration/questions/filtered-reference-data.spec.js
+++ b/integration-tests/integration/questions/filtered-reference-data.spec.js
@@ -42,16 +42,21 @@ context('Test filtered reference data fields', () => {
   })
 
   it('updates reference data fields when the target field is updated', () => {
+    const questionsPage = FilteredReferenceDataTestPage.goTo()
+
+    questionsPage
+      .questions()
+      .contains('div', 'Assessor Team')
+      .find('.govuk-label')
+      .then(options => {
+        const listOfOptions = [...options].map(o => o.textContent.trim())
+        expect(listOfOptions).to.deep.eq(['First Team', 'Second Team'])
+      })
+
     cy.intercept(
       'POST',
       '/e69a61ff-7395-4a12-b434-b1aa6478aded/episode/4511a3f6-7f51-4b96-b603-4e75eac0c839/referencedata/filtered',
     ).as('update')
-
-    const questionsPage = FilteredReferenceDataTestPage.goTo()
-
-    cy.wait('@update')
-      .its('response.statusCode')
-      .should('eq', 200)
 
     questionsPage
       .questions()

--- a/integration-tests/integration/questions/filtered-reference-data.spec.js
+++ b/integration-tests/integration/questions/filtered-reference-data.spec.js
@@ -11,24 +11,33 @@ context('Test filtered reference data fields', () => {
     questionsPage
       .questions()
       .eq(0)
-      .should('include.text', 'Assessor')
+      .should('include.text', 'Assessor Office')
 
     questionsPage
       .questions()
       .eq(1)
-      .should('include.text', 'Assessor Office')
+      .should('include.text', 'Assessor Team')
   })
 
   it('Populates reference data fields on page load', () => {
+    cy.intercept(
+      'POST',
+      '/e69a61ff-7395-4a12-b434-b1aa6478aded/episode/4511a3f6-7f51-4b96-b603-4e75eac0c839/referencedata/filtered',
+    ).as('update')
+
     const questionsPage = FilteredReferenceDataTestPage.goTo()
+
+    cy.wait('@update')
+      .its('response.statusCode')
+      .should('eq', 200)
 
     questionsPage
       .questions()
-      .contains('div', 'Assessor Office')
-      .find('option')
+      .contains('div', 'Assessor Team')
+      .find('.govuk-label')
       .then(options => {
-        const listOfOptions = [...options].map(o => o.text)
-        expect(listOfOptions).to.deep.eq(['First Office', 'Second Office'])
+        const listOfOptions = [...options].map(o => o.textContent.trim())
+        expect(listOfOptions).to.deep.eq(['First Team', 'Second Team'])
       })
   })
 
@@ -42,9 +51,9 @@ context('Test filtered reference data fields', () => {
 
     questionsPage
       .questions()
-      .contains('div', 'Assessor')
-      .find('select')
-      .select('second')
+      .contains('div', 'Assessor Office')
+      .find('[type="radio"]')
+      .check('second')
 
     cy.wait('@update')
       .its('response.statusCode')
@@ -52,11 +61,11 @@ context('Test filtered reference data fields', () => {
 
     questionsPage
       .questions()
-      .contains('div', 'Assessor Office')
-      .find('option')
+      .contains('div', 'Assessor Team')
+      .find('.govuk-label')
       .then(options => {
-        const listOfOptions = [...options].map(o => o.text)
-        expect(listOfOptions).to.deep.eq(['Third Office', 'Fourth Office'])
+        const listOfOptions = [...options].map(o => o.textContent.trim())
+        expect(listOfOptions).to.deep.eq(['Third Team', 'Fourth Team'])
       })
   })
 
@@ -70,9 +79,9 @@ context('Test filtered reference data fields', () => {
 
     questionsPage
       .questions()
-      .contains('div', 'Assessor')
-      .find('select')
-      .select('fail')
+      .contains('div', 'Assessor Office')
+      .find('[type="radio"]')
+      .check('fail')
 
     cy.wait('@update')
       .its('response.statusCode')
@@ -80,8 +89,8 @@ context('Test filtered reference data fields', () => {
 
     questionsPage
       .questions()
-      .contains('div', 'Assessor Office')
-      .find('option')
+      .contains('div', 'Assessor Team')
+      .find('.govuk-label')
       .should('not.exist')
   })
 })

--- a/integration-tests/integration/questions/filtered-reference-data.spec.js
+++ b/integration-tests/integration/questions/filtered-reference-data.spec.js
@@ -42,12 +42,16 @@ context('Test filtered reference data fields', () => {
   })
 
   it('updates reference data fields when the target field is updated', () => {
-    const questionsPage = FilteredReferenceDataTestPage.goTo()
-
     cy.intercept(
       'POST',
       '/e69a61ff-7395-4a12-b434-b1aa6478aded/episode/4511a3f6-7f51-4b96-b603-4e75eac0c839/referencedata/filtered',
     ).as('update')
+
+    const questionsPage = FilteredReferenceDataTestPage.goTo()
+
+    cy.wait('@update')
+      .its('response.statusCode')
+      .should('eq', 200)
 
     questionsPage
       .questions()

--- a/wiremock/responses/filteredReferenceData.json
+++ b/wiremock/responses/filteredReferenceData.json
@@ -12,11 +12,11 @@
       "body": [
         {
           "code": "100",
-          "description": "First Office"
+          "description": "First Team"
         },
         {
           "code": "101",
-          "description": "Second Office"
+          "description": "Second Team"
         }
       ]
     }
@@ -34,11 +34,11 @@
       "body": [
         {
           "code": "102",
-          "description": "Third Office"
+          "description": "Third Team"
         },
         {
           "code": "103",
-          "description": "Fourth Office"
+          "description": "Fourth Team"
         }
       ]
     }

--- a/wiremock/responses/questionGroups.json
+++ b/wiremock/responses/questionGroups.json
@@ -572,9 +572,9 @@
               {
                 "type": "question",
                 "questionId": "11111111-1111-1111-1111-111111111202",
-                "questionCode": "assessor",
-                "answerType": "dropdown",
-                "questionText": "Assessor",
+                "questionCode": "assessor_office",
+                "answerType": "radio",
+                "questionText": "Assessor Office",
                 "displayOrder": "1",
                 "mandatory": "yes",
                 "answerSchemas": [
@@ -603,9 +603,9 @@
               {
                 "type": "question",
                 "questionId": "11111111-1111-1111-1111-111111111203",
-                "questionCode": "assessor_office",
-                "answerType": "dropdown",
-                "questionText": "Assessor Office",
+                "questionCode": "assessor_team",
+                "answerType": "radio",
+                "questionText": "Assessor Team",
                 "displayOrder": "1",
                 "mandatory": "yes",
                 "answerSchemas": [],


### PR DESCRIPTION
### Context

This PR adds support for radio groups when fetching filtered reference data

### Intent

- Add support for radios in `filtered-reference-data.js` client-side code
- Update Wiremock to more accurately reflect a scenario for reference data