### PR TITLE
ARN 418 get user email

### DIFF
--- a/common/data/oauth.test.js
+++ b/common/data/oauth.test.js
@@ -1,0 +1,104 @@
+const nock = require('nock')
+const { getApiToken, getUserEmail, checkTokenIsActive } = require('./oauth')
+const redis = require('./redis')
+
+jest.mock('../config', () => ({
+  applicationInsights: { disabled: true },
+  apiClientId: 'foo',
+  apiClientSecret: 'bar',
+  apis: {
+    oauth: { timeout: 10000, url: 'http://hmpps-auth.mock' },
+  },
+}))
+
+jest.mock('../data/redis', () => ({
+  get: jest.fn(),
+  set: jest.fn(),
+}))
+
+describe('Oauth', () => {
+  let authService
+
+  beforeEach(() => {
+    authService = nock('http://hmpps-auth.mock')
+  })
+
+  afterEach(() => {
+    nock.abortPendingRequests()
+    nock.cleanAll()
+  })
+
+  describe('checkTokenIsActive', () => {
+    it('returns the token status', async () => {
+      authService
+        .post('/token/verify')
+        .matchHeader('authorization', 'Bearer FOO_TOKEN')
+        .reply(200, { active: true })
+
+      const isActive = await checkTokenIsActive('FOO_TOKEN')
+
+      expect(isActive).toEqual(true)
+    })
+
+    it('swallows exceptions', async () => {
+      authService
+        .get('/token/verify')
+        .matchHeader('authorization', 'Bearer FOO_TOKEN')
+        .reply(500)
+
+      const isActive = await checkTokenIsActive('FOO_TOKEN')
+
+      expect(isActive).toEqual(undefined)
+    })
+  })
+
+  describe('getUserEmail', () => {
+    it('returns the user email', async () => {
+      authService
+        .get('/api/me/email')
+        .matchHeader('authorization', 'Bearer FOO_TOKEN')
+        .reply(200, { email: 'foo@bar.baz' })
+
+      const email = await getUserEmail('FOO_TOKEN')
+
+      expect(email).toEqual('foo@bar.baz')
+    })
+
+    it('swallows exceptions', async () => {
+      authService
+        .get('/api/me/email')
+        .matchHeader('authorization', 'Bearer FOO_TOKEN')
+        .reply(500)
+
+      const email = await getUserEmail('FOO_TOKEN')
+
+      expect(email).toEqual(undefined)
+    })
+  })
+
+  describe('getApiToken', () => {
+    it('returns the token if found in cache', async () => {
+      authService
+        .post('/oauth/token?grant_type=client_credentials')
+        .matchHeader('authorization', 'Basic Zm9vOmJhcg==')
+        .reply(200, { access_token: 'FOO_TOKEN', expires_in: 12345 })
+
+      redis.get.mockResolvedValue('CACHED_TOKEN')
+
+      const token = await getApiToken()
+      expect(token).toEqual('CACHED_TOKEN')
+    })
+
+    it('fetches a new token if not found in cache', async () => {
+      authService
+        .post('/oauth/token?grant_type=client_credentials')
+        .matchHeader('authorization', 'Basic Zm9vOmJhcg==')
+        .reply(200, { access_token: 'FOO_TOKEN', expires_in: 12345 })
+
+      redis.get.mockResolvedValue()
+
+      const token = await getApiToken()
+      expect(token).toEqual('FOO_TOKEN')
+    })
+  })
+})

--- a/common/data/redis.js
+++ b/common/data/redis.js
@@ -1,0 +1,19 @@
+const redis = require('redis')
+const { promisify } = require('util')
+const config = require('../config')
+
+const redisClient = redis.createClient({
+  port: config.redis.port,
+  password: config.redis.password,
+  host: config.redis.host,
+  tls: config.redis.tls_enabled === 'true' ? {} : false,
+})
+
+const getAsync = promisify(redisClient.get).bind(redisClient)
+const setAsync = promisify(redisClient.set).bind(redisClient)
+
+module.exports = {
+  client: redisClient,
+  get: getAsync,
+  set: setAsync,
+}

--- a/common/middleware/getQuestionGroup.js
+++ b/common/middleware/getQuestionGroup.js
@@ -61,7 +61,7 @@ const usesStaticReferenceData = questionSchema =>
 const usesDynamicReferenceData = questionSchema =>
   questionSchema.referenceDataCategory && questionSchema.referenceDataCategory === 'FILTERED_REFERENCE_DATA'
 
-const applyStaticReferenceData = async (questionResponse, authorisationToken) => {
+const applyStaticReferenceData = async questionResponse => {
   const extractReferenceDataCategories = questionSchema => {
     if (questionSchema.type === 'group') {
       return questionSchema.contents.flatMap(extractReferenceDataCategories)
@@ -118,7 +118,7 @@ const applyStaticReferenceData = async (questionResponse, authorisationToken) =>
 module.exports = async ({ params: { groupId, subgroup = 0, page = 0 }, user }, res, next) => {
   try {
     const questionResponse = await getQuestionGroup(groupId, user?.token)
-    const hydratedQuestions = await applyStaticReferenceData(questionResponse, user?.token)
+    const hydratedQuestions = await applyStaticReferenceData(questionResponse)
 
     const thisQuestionGroup = hydratedQuestions.contents[subgroup].contents[page]
     const readOnlyToAttribute = q => {

--- a/common/middleware/getQuestionGroup.js
+++ b/common/middleware/getQuestionGroup.js
@@ -1,6 +1,7 @@
 // @ts-check
 const logger = require('../logging/logger')
 const { getQuestionGroup } = require('../data/hmppsAssessmentApi')
+const { getApiToken } = require('../data/oauth')
 const { getReferenceDataListByCategory } = require('../data/offenderAssessmentApi')
 const { processReplacements } = require('../utils/util')
 
@@ -79,9 +80,11 @@ const applyStaticReferenceData = async (questionResponse, authorisationToken) =>
     return questionResponse
   }
 
+  const apiToken = await getApiToken()
+
   const referenceDataRequests = Array.from(referenceDataCategories).map(async category => ({
     category,
-    data: await getReferenceDataListByCategory(category, authorisationToken),
+    data: await getReferenceDataListByCategory(category, apiToken),
   }))
 
   const referenceDataResponses = await Promise.all(referenceDataRequests)

--- a/common/middleware/getQuestionGroup.test.js
+++ b/common/middleware/getQuestionGroup.test.js
@@ -1,10 +1,15 @@
 const getQuestion = require('./getQuestionGroup')
 const { getQuestionGroup } = require('../data/hmppsAssessmentApi')
+const { getApiToken } = require('../data/oauth')
 const { getReferenceDataListByCategory } = require('../data/offenderAssessmentApi')
 const { processReplacements } = require('../utils/util')
 const {
   dev: { devAssessmentId },
 } = require('../config')
+
+jest.mock('../data/oauth', () => ({
+  getApiToken: jest.fn(),
+}))
 
 const questions = {
   type: 'group',
@@ -204,6 +209,7 @@ describe('getQuestionGroup middleware', () => {
   describe('applies static reference data to questions', () => {
     beforeEach(async () => {
       getReferenceDataListByCategory.mockResolvedValue([{ description: 'foo', code: 'bar' }])
+      getApiToken.mockResolvedValue('API_TOKEN')
     })
 
     it('fetches data for questions that have a reference data category', async () => {
@@ -243,8 +249,8 @@ describe('getQuestionGroup middleware', () => {
 
       await getQuestion(req, res, next)
 
-      expect(getReferenceDataListByCategory).toHaveBeenCalledWith('REFERENCE_DATA_CATEGORY_1', user.token)
-      expect(getReferenceDataListByCategory).toHaveBeenCalledWith('REFERENCE_DATA_CATEGORY_2', user.token)
+      expect(getReferenceDataListByCategory).toHaveBeenCalledWith('REFERENCE_DATA_CATEGORY_1', 'API_TOKEN')
+      expect(getReferenceDataListByCategory).toHaveBeenCalledWith('REFERENCE_DATA_CATEGORY_2', 'API_TOKEN')
 
       expect(res.locals.questionGroup.contents[0]).toMatchObject({
         type: 'question',

--- a/common/models/user.js
+++ b/common/models/user.js
@@ -1,0 +1,45 @@
+class User {
+  static from({ id, token, refreshToken, tokenLifetime, tokenExpiryTime, username, email } = {}) {
+    const user = new User()
+    user.id = id
+    user.token = token
+    user.refreshToken = refreshToken
+    user.tokenLifetime = tokenLifetime
+    user.tokenExpiryTime = tokenExpiryTime
+    user.username = username
+    user.email = email
+    return user
+  }
+
+  updateToken({ token, refreshToken, tokenExpiryTime } = {}) {
+    this.token = token
+    this.refreshToken = refreshToken
+    this.tokenExpiryTime = tokenExpiryTime
+    return this
+  }
+
+  withDetails({ email, username } = {}) {
+    this.email = email
+    this.username = username
+    return this
+  }
+
+  getDetails() {
+    return {
+      email: this.email,
+      username: this.username,
+    }
+  }
+
+  getSession() {
+    return {
+      id: this.id,
+      token: this.token,
+      refreshToken: this.refreshToken,
+      tokenLifetime: this.tokenLifetime,
+      tokenExpiryTime: this.tokenExpiryTime,
+    }
+  }
+}
+
+module.exports = User

--- a/common/models/user.js
+++ b/common/models/user.js
@@ -24,6 +24,10 @@ class User {
     return this
   }
 
+  setEmail(email) {
+    this.email = email
+  }
+
   getDetails() {
     return {
       email: this.email,

--- a/server.js
+++ b/server.js
@@ -15,7 +15,6 @@ const dateFilter = require('nunjucks-date-filter')
 const session = require('express-session')
 const helmet = require('helmet')
 const passport = require('passport')
-const redis = require('redis')
 const connectRedis = require('connect-redis')
 
 // Local dependencies
@@ -32,6 +31,7 @@ const { applicationInsights } = require('./common/config')
 const { encodeHTML, extractLink, doReplace } = require('./common/utils/util')
 const config = require('./common/config')
 const auth = require('./common/middleware/auth')
+const redis = require('./common/data/redis')
 
 // Global constants
 const { static: _static } = express
@@ -105,16 +105,9 @@ function initialiseGlobalMiddleware(app) {
     next()
   })
 
-  const redisClient = redis.createClient({
-    port: config.redis.port,
-    password: config.redis.password,
-    host: config.redis.host,
-    tls: config.redis.tls_enabled === 'true' ? {} : false,
-  })
-
   app.use(
     session({
-      store: new RedisStore({ client: redisClient }),
+      store: new RedisStore({ client: redis.client }),
       secret: config.sessionSecret,
       cookie: { secure: config.https, sameSite: 'lax', maxAge: 24 * 60 * 60 * 1000 }, // 24 hours
       resave: false, // redis implements touch so shouldn't need this


### PR DESCRIPTION
## Context

This PR updates the Passport integration to separate out user details and user session, the user details are cached with the key `user:${user.id}` - allowing backend services to retrieve the cached data by information passed in the JWT

## Intent

- Update passport integration to store user details and session data separately in Redis
- Fix issue where user token was passed in place of API bearer token
- Update OAuth client to cache API bearer token in Redis to support horizontal scaling