### PR TITLE
Add stack-trace to error page with feature toggle

### DIFF
--- a/app/error.njk
+++ b/app/error.njk
@@ -15,7 +15,19 @@
         Something went wrong.
       <h3>
       <p class="govuk-body">
+      {% if showDetailedErrors %}
+        {% if error %}
+          <h4 class="govuk-heading-s">Geek Stuff 👇</h4>
+          <div class="govuk-inset-text">
+            <p class="govuk-body govuk-!-font-weight-bold">
+              {{ error.message }}
+            </p>
+            <code>{{ error.stack }}</code>
+          </div>
+        {% endif %}
+      {% else %}
         {{ error }}
+      {% endif %}
       </p>
     </div>
   </div>

--- a/helm_deploy/hmpps-risk-assessment-ui/templates/_envs.tpl
+++ b/helm_deploy/hmpps-risk-assessment-ui/templates/_envs.tpl
@@ -61,4 +61,7 @@ env:
   - name: INGRESS_URL
     value: 'https://{{ .Values.ingress.host }}'
 
+  - name: SHOW_DETAILED_ERRORS
+    value: {{ .Values.env.SHOW_DETAILED_ERRORS | quote }}
+
 {{- end -}}

--- a/helm_deploy/values-development.yaml
+++ b/helm_deploy/values-development.yaml
@@ -30,6 +30,7 @@ env:
   HMPPS_ASSESSMENT_API_URL: http://hmpps-assessments-api.hmpps-assessments-dev.svc.cluster.local
   OFFENDER_ASSESSMENT_API_URL: https://offender-dev.aks-dev-1.studio-hosting.service.justice.gov.uk
   OAUTH_ENDPOINT_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+  SHOW_DETAILED_ERRORS: true
 
 allow_list:
   office: "217.33.148.210/32"

--- a/server.js
+++ b/server.js
@@ -95,6 +95,7 @@ function initialiseGlobalMiddleware(app) {
 
   app.use((req, res, next) => {
     res.locals.asset_path = '/public/' // eslint-disable-line camelcase
+    res.locals.showDetailedErrors = process.env.SHOW_DETAILED_ERRORS === 'true'
     noCache(res)
     next()
   })


### PR DESCRIPTION
## Context

Not sure if this is something we want, but might help diagnose errors thrown in the application 🤔 
This PR adds the stack trace to error pages, this is behind a feature toggle and enabled for Development. 

## Screenshots

<img width="1373" alt="Screenshot 2021-05-27 at 11 36 17" src="https://user-images.githubusercontent.com/20080441/119812186-cbbbd080-bedf-11eb-9deb-0303cdd3b367.png">
