### PR TITLE
ARN 418 handle auth failures

### DIFF
--- a/app/error.njk
+++ b/app/error.njk
@@ -9,10 +9,10 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
-        Oh dear!
+        {{ heading | default("Oh dear!") }}
       </h1>
       <h3 class="govuk-heading-m">
-        Something went wrong.
+        {{ subHeading | default("Something went wrong") }}
       <h3>
       <p class="govuk-body">
       {% if showDetailedErrors %}
@@ -26,7 +26,7 @@
           </div>
         {% endif %}
       {% else %}
-        {{ error }}
+        {{ error.message }}
       {% endif %}
       </p>
     </div>

--- a/common/data/oauth.js
+++ b/common/data/oauth.js
@@ -9,6 +9,7 @@ const {
 } = require('../config')
 const redis = require('./redis')
 const { SIXTY_SECONDS } = require('../utils/constants')
+const { AuthenticationError } = require('../utils/errors')
 
 const checkTokenIsActive = async token => {
   return superagent
@@ -31,6 +32,7 @@ const getUserEmail = async token => {
     })
     .catch(error => {
       logger.error(`Unable to get user email: ${error.message}`)
+      throw new AuthenticationError('Unable to fetch user details')
     })
 }
 

--- a/common/data/oauth.test.js
+++ b/common/data/oauth.test.js
@@ -1,4 +1,5 @@
 const nock = require('nock')
+const { AuthenticationError } = require('../utils/errors')
 const { getApiToken, getUserEmail, checkTokenIsActive } = require('./oauth')
 const redis = require('./redis')
 
@@ -64,15 +65,13 @@ describe('Oauth', () => {
       expect(email).toEqual('foo@bar.baz')
     })
 
-    it('swallows exceptions', async () => {
+    it('Throws AuthenticationError when unable to find user', async () => {
       authService
         .get('/api/me/email')
         .matchHeader('authorization', 'Bearer FOO_TOKEN')
-        .reply(500)
+        .reply(404)
 
-      const email = await getUserEmail('FOO_TOKEN')
-
-      expect(email).toEqual(undefined)
+      await expect(getUserEmail('FOO_TOKEN')).rejects.toThrow(new AuthenticationError('Unable to fetch user details'))
     })
   })
 

--- a/common/data/offenderAssessmentApi.js
+++ b/common/data/offenderAssessmentApi.js
@@ -1,6 +1,7 @@
 const superagent = require('superagent')
 const logger = require('../logging/logger')
 const { getCorrelationId } = require('../utils/util')
+const { AuthenticationError } = require('../utils/errors')
 const {
   apis: {
     offenderAssessments: { timeout, url },
@@ -12,9 +13,16 @@ const getReferenceDataListByCategory = (category, authorisationToken) => {
   return getData(path, authorisationToken)
 }
 
-const getUserByEmail = (email, authorisationToken) => {
-  const path = `${url}/authentication/user/email`
-  return postData(path, authorisationToken, { email })
+const getUserByEmail = async (email, authorisationToken) => {
+  try {
+    const path = `${url}/authentication/user/email`
+    return await postData(path, authorisationToken, { email })
+  } catch (error) {
+    if (error.status === 404) {
+      throw new AuthenticationError('OASys account not found')
+    }
+    throw new AuthenticationError('Unable to fetch OASys user details')
+  }
 }
 
 const getData = (path, authorisationToken) => {

--- a/common/middleware/auth.test.js
+++ b/common/middleware/auth.test.js
@@ -233,7 +233,8 @@ describe('Auth', () => {
 
       expect(passport.authenticate).toHaveBeenCalledWith('oauth2', {
         successReturnToOrRedirect: req.session.returnUrl,
-        failureRedirect: '/login/error',
+        failureRedirect: '/login',
+        failureFlash: true,
       })
 
       expect(mockPassportAuthenticateMiddleware).toHaveBeenCalledWith(req, res, next)
@@ -425,7 +426,7 @@ describe('Auth', () => {
 
       await deserializer(User.from({ id: 1, token: 'FOO_TOKEN' }), callback)
 
-      expect(callback).toHaveBeenCalledWith('💥', { id: 1, token: 'FOO_TOKEN' })
+      expect(callback).toHaveBeenCalledWith('💥')
     })
   })
 })

--- a/common/templates/partials/header.njk
+++ b/common/templates/partials/header.njk
@@ -25,13 +25,14 @@
       <nav class="moj-header__navigation" aria-label="Account navigation">
 
         <ul class="moj-header__navigation-list">
-          <li class="moj-header__navigation-item">
-            {{ username }}
-          </li>
-
-          <li class="moj-header__navigation-item">
-            <a class="govuk-header__link" href="/logout">Sign out</a>
-          </li>
+          {% if username %}
+            <li class="moj-header__navigation-item">
+              {{ username }}
+            </li>
+            <li class="moj-header__navigation-item">
+              <a class="govuk-header__link" href="/logout">Sign out</a>
+            </li>
+          {% endif %}
         </ul>
 
       </nav>

--- a/common/utils/errors.js
+++ b/common/utils/errors.js
@@ -1,0 +1,17 @@
+class AuthenticationError extends Error {
+  constructor(message, ...params) {
+    super(...params)
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, AuthenticationError)
+    }
+
+    this.name = 'AuthenticationError'
+    this.message = message || 'There was a problem signing in'
+    this.status = 401
+  }
+}
+
+module.exports = {
+  AuthenticationError,
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6022,6 +6022,11 @@
       "integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
       "dev": true
     },
+    "connect-flash": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/connect-flash/-/connect-flash-0.1.1.tgz",
+      "integrity": "sha1-2GMPJtlaf4UfmVax6MxnMvO2qjA="
+    },
     "connect-redis": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-5.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "body-parser": "1.19.0",
     "cls-hooked": "^4.2.2",
     "compression": "^1.7.4",
+    "connect-flash": "^0.1.1",
     "connect-redis": "^5.2.0",
     "continuation-local-storage": "^3.2.1",
     "cookie-session": "^1.3.3",

--- a/server.js
+++ b/server.js
@@ -16,6 +16,7 @@ const session = require('express-session')
 const helmet = require('helmet')
 const passport = require('passport')
 const connectRedis = require('connect-redis')
+const flash = require('connect-flash')
 
 // Local dependencies
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -125,6 +126,7 @@ function initialiseGlobalMiddleware(app) {
   auth.init()
   app.use(passport.initialize())
   app.use(passport.session())
+  app.use(flash())
 
   // must be after session since we need session
   app.use(mdcSetup)

--- a/wiremock/auth.js
+++ b/wiremock/auth.js
@@ -135,7 +135,7 @@ const stubEmail = username =>
   stubFor({
     request: {
       method: 'GET',
-      url: `/auth/api/user/${encodeURI(username)}/email`,
+      url: `/auth/api/me/email`,
     },
     response: {
       status: 200,
@@ -143,7 +143,6 @@ const stubEmail = username =>
         'Content-Type': 'application/json;charset=UTF-8',
       },
       jsonBody: {
-        username,
         email: `${username}@gov.uk`,
       },
     },


### PR DESCRIPTION
## Context

Currently failures when fetching user details fails with a generic error message. This PR aims to update the application to gracefully handle failures when hydrating the user object.

## Intent

- Improve error handling when hydrating the user object
- Add error handlers for authentication and the other routes

## Screenshots

**Unable to fetch user email from HMPPS auth**
<img width="1476" alt="Screenshot 2021-05-28 at 15 33 54" src="https://user-images.githubusercontent.com/20080441/120002706-00f21c80-bfcd-11eb-82bc-903f1e0ca6f5.png">
**Unable to fetch OASys user - not found for the provided email**
<img width="1461" alt="Screenshot 2021-05-28 at 15 36 02" src="https://user-images.githubusercontent.com/20080441/120002710-018ab300-bfcd-11eb-8f73-301caf50b84c.png">
**Unable to fetch OASys user - something else has gone wrong**
<img width="1491" alt="Screenshot 2021-05-28 at 15 37 08" src="https://user-images.githubusercontent.com/20080441/120002712-02234980-bfcd-11eb-8c8e-1769f27101a7.png">
**Generic error handling**
<img width="1467" alt="Screenshot 2021-05-28 at 15 40 42" src="https://user-images.githubusercontent.com/20080441/120002716-02234980-bfcd-11eb-9bf1-4323c6b6bad3.png">
**Page not found**
<img width="1452" alt="Screenshot 2021-05-28 at 15 41 45" src="https://user-images.githubusercontent.com/20080441/120002718-02bbe000-bfcd-11eb-8e7f-0e98f3dc4f32.png">

## Considerations

The content for the errors is placeholder - with the focus of this PR to improve our error handling around auth
