### PR TITLE
Add area selection check to all assessment routes

### DIFF
--- a/app/areaSelectionPage/get.controller.js
+++ b/app/areaSelectionPage/get.controller.js
@@ -4,8 +4,7 @@ const { getApiToken } = require('../../common/data/oauth')
 
 const areaSelectionController = async (req, res) => {
   try {
-    const [flashRegions] = req.flash('regions')
-    let regions = typeof flashRegions === 'string' ? JSON.parse(flashRegions) : []
+    let regions = req.session.regions || []
     if (regions.length === 0) {
       const apiToken = await getApiToken()
       const userProfile = await getUserProfile(req.user?.oasysUserCode, apiToken)

--- a/app/areaSelectionPage/get.controller.test.js
+++ b/app/areaSelectionPage/get.controller.test.js
@@ -1,8 +1,15 @@
 const { areaSelectionController } = require('./get.controller')
+const { getUserProfile } = require('../../common/data/offenderAssessmentApi')
+
+jest.mock('../../common/data/offenderAssessmentApi', () => ({
+  getUserProfile: jest.fn(),
+}))
 
 describe('get areas', () => {
   const req = {
-    flash: jest.fn(),
+    session: {
+      save: jest.fn(),
+    },
   }
   const res = {
     render: jest.fn(),
@@ -27,7 +34,7 @@ describe('get areas', () => {
         code: 'LAN2',
       },
     ]
-    req.flash.mockReturnValue([JSON.stringify(testRegions)])
+    req.session.regions = testRegions
   })
 
   it('should call render with the correct areas', async () => {
@@ -57,10 +64,8 @@ describe('get areas', () => {
 
   it('should render the error page', async () => {
     const theError = new Error('Error message')
-    req.flash.mockImplementation(() => {
-      throw theError
-    })
-    await areaSelectionController(req, res)
+    getUserProfile.mockRejectedValue(theError)
+    await areaSelectionController({ ...req, session: {} }, res)
     expect(res.render).toHaveBeenCalledWith(`app/error`, { error: theError })
   })
 })

--- a/app/areaSelectionPage/post.controller.js
+++ b/app/areaSelectionPage/post.controller.js
@@ -1,9 +1,5 @@
 const { cacheUserDetailsWithRegion } = require('../../common/data/userDetailsCache')
 
-const {
-  dev: { devAssessmentId },
-} = require('../../common/config')
-
 const redirectToAssessmentList = async (req, res) => {
   try {
     const { user } = req
@@ -11,7 +7,11 @@ const redirectToAssessmentList = async (req, res) => {
 
     await cacheUserDetailsWithRegion(user.id, areaInfo.areaCode, areaInfo.areaName)
 
-    return res.redirect(`/${devAssessmentId}/questiongroup/pre_sentence_assessment/summary`)
+    const redirectUrl = req.session.redirectUrl || '/'
+    delete req.session.redirectUrl
+    req.session.save()
+
+    return res.redirect(redirectUrl)
   } catch (error) {
     return res.render('app/error', { error })
   }

--- a/app/router.js
+++ b/app/router.js
@@ -43,6 +43,14 @@ const {
   checkForTokenRefresh,
 } = require('../common/middleware/auth')
 
+const { checkUserHasAreaSelected } = require('../common/middleware/area-selection')
+
+const {
+  dev: { devAssessmentId },
+} = require('../common/config')
+
+const assessmentUrl = `/${devAssessmentId}/questiongroup/pre_sentence_assessment/summary`
+
 // Export
 module.exports = app => {
   // app.get('/health', (req, res, next) => {
@@ -89,11 +97,12 @@ module.exports = app => {
   app.get(`/`, (req, res) => {
     res.redirect('/start')
   })
-  app.get(`/start`, startController)
+  app.get(`/start`, checkUserHasAreaSelected(assessmentUrl), startController)
 
   app.get(`/area-selection`, areaSelectionController)
   app.post('/area-selection', redirectToAssessmentList)
 
+  app.get('*', checkUserHasAreaSelected())
   app.get(`/:assessmentId/assessments`, getOffenderDetails, displayAssessmentsList)
 
   app.get(`/:assessmentId/questiongroup/:groupId/summary`, getOffenderDetails, displayOverview)

--- a/app/start/get.controller.js
+++ b/app/start/get.controller.js
@@ -1,23 +1,8 @@
-const { getUserProfile } = require('../../common/data/offenderAssessmentApi')
-const { cacheUserDetailsWithRegion } = require('../../common/data/userDetailsCache')
-
 const {
   dev: { devAssessmentId },
 } = require('../../common/config')
-const { getApiToken } = require('../../common/data/oauth')
 
 const startController = async (req, res) => {
-  const { user } = req
-  if (user && (user.areaCode === undefined || user.areaCode === null)) {
-    const apiToken = await getApiToken()
-    const { regions } = await getUserProfile(user.oasysUserCode, apiToken)
-    if (regions.length === 1) {
-      await cacheUserDetailsWithRegion(user.id, regions[0].code, regions[0].name)
-    } else {
-      req.flash('regions', JSON.stringify(regions))
-      return res.redirect(`/area-selection`)
-    }
-  }
   return res.render(`${__dirname}/index`, { assessmentId: devAssessmentId })
 }
 

--- a/common/data/userDetailsCache.js
+++ b/common/data/userDetailsCache.js
@@ -16,8 +16,8 @@ const cacheUserDetails = async (userId, oasysUser) => {
 }
 
 const cacheUserDetailsWithRegion = async (userId, areaCode, areaName) => {
-  const serializedDetails = await getCachedUserDetails(userId)
-  const userDetails = new User().withDetails(serializedDetails).setArea({ areaCode, areaName })
+  const existingDetails = await getCachedUserDetails(userId)
+  const userDetails = new User().withDetails({ ...existingDetails, areaCode, areaName })
   await redis.set(`user:${userId}`, JSON.stringify(userDetails))
 }
 

--- a/common/middleware/area-selection.js
+++ b/common/middleware/area-selection.js
@@ -1,0 +1,30 @@
+const { getUserProfile } = require('../data/offenderAssessmentApi')
+const { cacheUserDetailsWithRegion } = require('../data/userDetailsCache')
+const { getApiToken } = require('../data/oauth')
+const logger = require('../logging/logger')
+
+const checkUserHasAreaSelected = overrideUrl => async (req, res, next) => {
+  try {
+    const { user } = req
+    if (user && (user.areaCode === undefined || user.areaCode === null)) {
+      const apiToken = await getApiToken()
+      const { regions } = await getUserProfile(user.oasysUserCode, apiToken)
+      if (regions.length === 1) {
+        await cacheUserDetailsWithRegion(user.id, regions[0].code, regions[0].name)
+      } else {
+        req.session.regions = regions
+        req.session.redirectUrl = overrideUrl || req.originalUrl
+        req.session.save()
+        return res.redirect(`/area-selection`)
+      }
+    }
+    return next()
+  } catch (error) {
+    logger.error(`Unable to check user has area selected, error: ${error}`)
+    return res.render('app/error', { error })
+  }
+}
+
+module.exports = {
+  checkUserHasAreaSelected,
+}

--- a/common/middleware/area-selection.test.js
+++ b/common/middleware/area-selection.test.js
@@ -1,0 +1,107 @@
+const { checkUserHasAreaSelected } = require('./area-selection')
+const { getUserProfile } = require('../data/offenderAssessmentApi')
+const { cacheUserDetailsWithRegion } = require('../data/userDetailsCache')
+const { getApiToken } = require('../data/oauth')
+
+jest.mock('../data/offenderAssessmentApi', () => ({
+  getUserProfile: jest.fn(),
+}))
+
+jest.mock('../data/userDetailsCache', () => ({
+  cacheUserDetailsWithRegion: jest.fn(),
+}))
+
+jest.mock('../data/oauth', () => ({
+  getApiToken: jest.fn(),
+}))
+
+describe('checkUserHasAreaSelected', () => {
+  const defaultSession = { save: jest.fn() }
+  const res = { redirect: jest.fn(), render: jest.fn() }
+  const next = jest.fn()
+
+  beforeEach(() => {
+    next.mockReset()
+    defaultSession.save.mockReset()
+    res.redirect.mockReset()
+    res.render.mockReset()
+  })
+
+  it('does nothing when a region is already selected', async () => {
+    const middleware = checkUserHasAreaSelected()
+
+    await middleware({ defaultSession, user: { areaCode: 'ABC' } }, res, next)
+
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('defaults when only a single region is available', async () => {
+    const req = { session: { ...defaultSession }, user: {} }
+    const regions = [{ code: 'ABC', name: 'Abc' }]
+    const middleware = checkUserHasAreaSelected()
+
+    getApiToken.mockResolvedValue('FOO_TOKEN')
+    getUserProfile.mockResolvedValue({ regions })
+
+    await middleware(req, res, next)
+
+    expect(cacheUserDetailsWithRegion).toHaveBeenCalled()
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('redirects to the area selection page when user has no area', async () => {
+    const originalUrl = '/foo/bar'
+    const req = { session: { ...defaultSession }, user: {}, originalUrl }
+    const regions = [
+      { code: 'ABC', name: 'Abc' },
+      { code: 'DEF', name: 'Def' },
+    ]
+
+    const middleware = checkUserHasAreaSelected()
+
+    getApiToken.mockResolvedValue('FOO_TOKEN')
+    getUserProfile.mockResolvedValue({ regions })
+
+    await middleware(req, res, next)
+
+    expect(req.session.save).toHaveBeenCalled()
+    expect(req.session.regions).toEqual(regions)
+    expect(req.session.redirectUrl).toEqual(originalUrl)
+    expect(res.redirect).toHaveBeenCalled()
+  })
+
+  it('allows an override for the redirect URL', async () => {
+    const redirectUrl = '/foo/bar'
+    const req = { session: { ...defaultSession }, user: {} }
+    const regions = [
+      { code: 'ABC', name: 'Abc' },
+      { code: 'DEF', name: 'Def' },
+    ]
+
+    const middleware = checkUserHasAreaSelected(redirectUrl)
+
+    getApiToken.mockResolvedValue('FOO_TOKEN')
+    getUserProfile.mockResolvedValue({ regions })
+
+    await middleware(req, res, next)
+
+    expect(req.session.save).toHaveBeenCalled()
+    expect(req.session.regions).toEqual(regions)
+    expect(req.session.redirectUrl).toEqual(redirectUrl)
+    expect(res.redirect).toHaveBeenCalled()
+  })
+
+  it('should render the error page', async () => {
+    const error = new Error('Error message')
+    const req = { session: { ...defaultSession }, user: {} }
+
+    const middleware = checkUserHasAreaSelected()
+
+    getApiToken.mockResolvedValue('FOO_TOKEN')
+    getUserProfile.mockRejectedValue(error)
+
+    await middleware(req, res, next)
+
+    expect(res.render).toHaveBeenCalledWith(`app/error`, { error })
+  })
+})

--- a/common/middleware/auth.test.js
+++ b/common/middleware/auth.test.js
@@ -399,6 +399,8 @@ describe('Auth', () => {
         email: 'foo@bar.baz',
         isActive: true,
         oasysUserCode: 'SUPPORT1',
+        areaCode: 'HFS',
+        areaName: 'Hertfordshire',
       })
       expect(user.getSession()).toEqual({
         id: 1,

--- a/common/models/user.js
+++ b/common/models/user.js
@@ -16,15 +16,11 @@ class User {
     return this
   }
 
-  withDetails({ isActive, email, oasysUserCode, username } = {}) {
+  withDetails({ isActive, email, oasysUserCode, username, areaCode, areaName } = {}) {
     this.isActive = isActive
     this.email = email
     this.oasysUserCode = oasysUserCode
     this.username = username
-    return this
-  }
-
-  setArea({ areaCode, areaName } = {}) {
     this.areaCode = areaCode
     this.areaName = areaName
     return this
@@ -36,6 +32,8 @@ class User {
       email: this.email,
       oasysUserCode: this.oasysUserCode,
       username: this.username,
+      areaCode: this.areaCode,
+      areaName: this.areaName,
     }
   }
 


### PR DESCRIPTION
## Context

Currently there is an issue when accessing an assessment page directly after logging in, this is due to the area being unset and the user not being redirected.

## Steps to reproduce

- Sign in
- Go to an assessment page (copy this url)
- Sign out
- Go to the assessment page (paste the url copied previously

Expected behaviour: I am signed in, asked to select an area and taken to the assessment page
Actual behaviour: The user is presented an error

## Intent

This PR changes the following

- Extract the code to check for selected region to middleware
- Check for selected area and redirect for all assessment routes
- Simplify interface for User model
- Remove `connect-flash`