### PR TITLE
Add initial error handling when creating assessments

### DIFF
--- a/app/assessmentFromCrn/post.controller.js
+++ b/app/assessmentFromCrn/post.controller.js
@@ -1,4 +1,3 @@
-// const { logger } = require('../../common/logging/logger')
 const { assessmentSupervision } = require('../../common/data/hmppsAssessmentApi')
 
 const getErrorMessageFor = (reason, offender, user) => {

--- a/app/assessmentFromCrn/post.controller.js
+++ b/app/assessmentFromCrn/post.controller.js
@@ -1,12 +1,15 @@
 // const { logger } = require('../../common/logging/logger')
 const { assessmentSupervision } = require('../../common/data/hmppsAssessmentApi')
 
-const getErrorMessageFor = (reason, offenderDetails, user) => {
+const getErrorMessageFor = (reason, offender, user) => {
   if (reason === 'OASYS_PERMISSION') {
     return 'You do not have permission to complete this type of assessment. Speak to your manager and ask them to request a change to your level of authorisation.'
   }
   if (reason === 'DUPLICATE_OFFENDER_RECORD') {
-    return `${offenderDetails.name} is showing as a possible duplicate record under ${user.areaName} PNC ${offenderDetails.pnc} Log into OASys to manage the duplication. If you need help, contact the OASys Application Support team`
+    return `${offender?.name || 'The offender'} is showing as a possible duplicate record under ${
+      user.areaName
+    } PNC ${offender?.pnc ||
+      ''} Log into OASys to manage the duplication. If you need help, contact the OASys Application Support team`
   }
 
   return 'Something went wrong' // Unhandled exception
@@ -19,7 +22,9 @@ const startAssessment = async (crn, deliusEventId, assessmentType, user, res) =>
 
     if (!ok) {
       // get offender details?
-      return res.render('app/error', { error: new Error(getErrorMessageFor(response.reason, {}, user)) })
+      return res.render('app/error', {
+        error: new Error(getErrorMessageFor(response.reason, response.offenderContext, user)),
+      })
     }
 
     return res.redirect(`/${response.assessmentUuid}/questionGroup/pre_sentence_assessment/summary`)

--- a/app/assessmentFromCrn/post.controller.js
+++ b/app/assessmentFromCrn/post.controller.js
@@ -1,30 +1,48 @@
 // const { logger } = require('../../common/logging/logger')
 const { assessmentSupervision } = require('../../common/data/hmppsAssessmentApi')
 
-const startAssessmentFromCrn = ({ params: { crn, deliusEventId, assessmentType }, user }, res) => {
-  return startAssessment(crn, deliusEventId, assessmentType, user?.token, user?.id, res)
+const getErrorMessageFor = (status, offenderDetails, user) => {
+  // We should use an error enum here, status codes may be a bit ambiguous
+  if (status === 401) {
+    return 'You do not have permission to complete this type of assessment. Speak to your manager and ask them to request a change to your level of authorisation.'
+  }
+  if (status === 400) {
+    return `${offenderDetails.name} is showing as a possible duplicate record under ${user.areaName} PNC ${offenderDetails.pnc} Log into OASys to manage the duplication. If you need help, contact the OASys Application Support team`
+  }
+
+  return 'Something went wrong' // Unhandled exception
 }
 
-const startAssessmentFromForm = ({ body, user }, res) => {
-  const { crn, deliusEventId, assessmentType } = body
-  return startAssessment(crn, deliusEventId, assessmentType, user?.token, user?.id, res)
-}
-
-const startAssessment = async (crn, deliusEventId, assessmentType, authorisationToken, userId, res) => {
+const startAssessment = async (crn, deliusEventId, assessmentType, user, res) => {
   try {
     // eslint-disable-next-line no-unused-vars
-    const [ok, assessment] = await assessmentSupervision(
-      { crn, deliusEventId, assessmentType },
-      authorisationToken,
-      userId,
-    )
-    return res.redirect(`/${assessment.assessmentUuid}/questionGroup/pre_sentence_assessment/summary`)
+    const [ok, response] = await assessmentSupervision({ crn, deliusEventId, assessmentType }, user?.token, user?.id)
+
+    if (!ok) {
+      // get offender details?
+      return res.render('app/error', { error: new Error(getErrorMessageFor(response.status, {}, user)) })
+    }
+
+    return res.redirect(`/${response.assessmentUuid}/questionGroup/pre_sentence_assessment/summary`)
   } catch (error) {
     return res.render('app/error', { error })
   }
 }
 
+const createStartAssessmentFromCrnMiddleware = (start = startAssessment) => {
+  return function startAssessmentFromCrn({ params: { crn, deliusEventId, assessmentType }, user }, res) {
+    return start(crn, deliusEventId, assessmentType, user, res)
+  }
+}
+
+const createStartAssessmentFromFormMiddleware = (start = startAssessment) => {
+  return function startAssessmentFromForm({ body, user }, res) {
+    const { crn, deliusEventId, assessmentType } = body
+    return start(crn, deliusEventId, assessmentType, user, res)
+  }
+}
+
 module.exports = {
-  startAssessmentFromCrn,
-  startAssessmentFromForm,
+  startAssessmentFromCrn: createStartAssessmentFromCrnMiddleware,
+  startAssessmentFromForm: createStartAssessmentFromFormMiddleware,
 }

--- a/app/assessmentFromCrn/post.controller.js
+++ b/app/assessmentFromCrn/post.controller.js
@@ -1,14 +1,11 @@
 const { assessmentSupervision } = require('../../common/data/hmppsAssessmentApi')
 
-const getErrorMessageFor = (reason, offender, user) => {
+const getErrorMessageFor = (reason, user) => {
   if (reason === 'OASYS_PERMISSION') {
     return 'You do not have permission to complete this type of assessment. Speak to your manager and ask them to request a change to your level of authorisation.'
   }
   if (reason === 'DUPLICATE_OFFENDER_RECORD') {
-    return `${offender?.name || 'The offender'} is showing as a possible duplicate record under ${
-      user.areaName
-    } PNC ${offender?.pnc ||
-      ''} Log into OASys to manage the duplication. If you need help, contact the OASys Application Support team`
+    return `The offender is showing as a possible duplicate record under ${user.areaName}. Log into OASys to manage the duplication. If you need help, contact the OASys Application Support team`
   }
 
   return 'Something went wrong' // Unhandled exception
@@ -22,7 +19,7 @@ const startAssessment = async (crn, deliusEventId, assessmentType, user, res) =>
     if (!ok) {
       // get offender details?
       return res.render('app/error', {
-        error: new Error(getErrorMessageFor(response.reason, response.offenderContext, user)),
+        error: new Error(getErrorMessageFor(response.reason, user)),
       })
     }
 

--- a/app/assessmentFromCrn/post.controller.test.js
+++ b/app/assessmentFromCrn/post.controller.test.js
@@ -55,7 +55,7 @@ describe('POST: Start an assessment', () => {
         user,
       }
 
-      const apiResponse = [false, { status: 401, reason: 'OASYS_PERMISSION' }]
+      const apiResponse = [false, { status: 403, reason: 'OASYS_PERMISSION' }]
 
       assessmentSupervision.mockResolvedValue(apiResponse)
 
@@ -134,7 +134,7 @@ describe('POST: Start an assessment', () => {
         user,
       }
 
-      const apiResponse = [false, { status: 401, reason: 'OASYS_PERMISSION' }]
+      const apiResponse = [false, { status: 403, reason: 'OASYS_PERMISSION' }]
 
       assessmentSupervision.mockResolvedValue(apiResponse)
 

--- a/app/assessmentFromCrn/post.controller.test.js
+++ b/app/assessmentFromCrn/post.controller.test.js
@@ -1,0 +1,167 @@
+const { startAssessmentFromCrn, startAssessmentFromForm } = require('./post.controller')
+const { assessmentSupervision } = require('../../common/data/hmppsAssessmentApi')
+
+jest.mock('../../common/data/hmppsAssessmentApi', () => ({
+  assessmentSupervision: jest.fn(),
+}))
+
+describe('POST: Start an assessment', () => {
+  const user = {
+    id: 1,
+    areaName: 'USER_AREA',
+    token: 'USER_TOKEN',
+  }
+
+  const res = {
+    redirect: jest.fn(),
+    render: jest.fn(),
+  }
+
+  describe('from CRN', () => {
+    const middleware = startAssessmentFromCrn()
+
+    beforeEach(() => {
+      assessmentSupervision.mockReset()
+      res.redirect.mockReset()
+      res.render.mockReset()
+    })
+
+    it('redirects on success', async () => {
+      const req = {
+        params: {
+          crn: 'CRN',
+          deliusEventId: 'DELIUS_EVENT_ID',
+          assessmentType: 'ASSESSMENT_TYPE',
+        },
+        user,
+      }
+
+      const apiResponse = [true, { assessmentUuid: 'ASSESSMENT_UUID' }]
+
+      assessmentSupervision.mockResolvedValue(apiResponse)
+
+      await middleware(req, res)
+
+      expect(res.redirect).toHaveBeenCalledWith('/ASSESSMENT_UUID/questionGroup/pre_sentence_assessment/summary')
+    })
+
+    it('renders an error when the user does not have permission', async () => {
+      const req = {
+        params: {
+          crn: 'CRN',
+          deliusEventId: 'DELIUS_EVENT_ID',
+          assessmentType: 'ASSESSMENT_TYPE',
+        },
+        user,
+      }
+
+      const apiResponse = [false, { status: 401 }]
+
+      assessmentSupervision.mockResolvedValue(apiResponse)
+
+      await middleware(req, res)
+
+      const theError = new Error(
+        'You do not have permission to complete this type of assessment. Speak to your manager and ask them to request a change to your level of authorisation.',
+      )
+      expect(res.render).toHaveBeenCalledWith('app/error', { error: theError })
+    })
+
+    it('renders an error when attempting to create a duplicate assessment', async () => {
+      const req = {
+        params: {
+          crn: 'CRN',
+          deliusEventId: 'DELIUS_EVENT_ID',
+          assessmentType: 'ASSESSMENT_TYPE',
+        },
+        user,
+      }
+
+      const apiResponse = [false, { status: 400 }]
+
+      assessmentSupervision.mockResolvedValue(apiResponse)
+
+      await middleware(req, res)
+
+      // These undefined values will need updating when we decide how to handle retrieving user details on error
+      const theError = new Error(
+        `${undefined} is showing as a possible duplicate record under USER_AREA PNC ${undefined} Log into OASys to manage the duplication. If you need help, contact the OASys Application Support team`,
+      )
+      expect(res.render).toHaveBeenCalledWith('app/error', { error: theError })
+    })
+  })
+
+  describe('from form', () => {
+    const middleware = startAssessmentFromForm()
+
+    beforeEach(() => {
+      assessmentSupervision.mockReset()
+      res.redirect.mockReset()
+      res.render.mockReset()
+    })
+
+    it('redirects on success', async () => {
+      const req = {
+        body: {
+          crn: 'CRN',
+          deliusEventId: 'DELIUS_EVENT_ID',
+          assessmentType: 'ASSESSMENT_TYPE',
+        },
+        user,
+      }
+
+      const apiResponse = [true, { assessmentUuid: 'ASSESSMENT_UUID' }]
+
+      assessmentSupervision.mockResolvedValue(apiResponse)
+
+      await middleware(req, res)
+
+      expect(res.redirect).toHaveBeenCalledWith('/ASSESSMENT_UUID/questionGroup/pre_sentence_assessment/summary')
+    })
+
+    it('renders an error when the user does not have permission', async () => {
+      const req = {
+        body: {
+          crn: 'CRN',
+          deliusEventId: 'DELIUS_EVENT_ID',
+          assessmentType: 'ASSESSMENT_TYPE',
+        },
+        user,
+      }
+
+      const apiResponse = [false, { status: 401 }]
+
+      assessmentSupervision.mockResolvedValue(apiResponse)
+
+      await middleware(req, res)
+
+      const theError = new Error(
+        'You do not have permission to complete this type of assessment. Speak to your manager and ask them to request a change to your level of authorisation.',
+      )
+      expect(res.render).toHaveBeenCalledWith('app/error', { error: theError })
+    })
+
+    it('renders an error when attempting to create a duplicate assessment', async () => {
+      const req = {
+        body: {
+          crn: 'CRN',
+          deliusEventId: 'DELIUS_EVENT_ID',
+          assessmentType: 'ASSESSMENT_TYPE',
+        },
+        user,
+      }
+
+      const apiResponse = [false, { status: 400 }]
+
+      assessmentSupervision.mockResolvedValue(apiResponse)
+
+      await middleware(req, res)
+
+      // These undefined values will need updating when we decide how to handle retrieving user details on error
+      const theError = new Error(
+        `${undefined} is showing as a possible duplicate record under USER_AREA PNC ${undefined} Log into OASys to manage the duplication. If you need help, contact the OASys Application Support team`,
+      )
+      expect(res.render).toHaveBeenCalledWith('app/error', { error: theError })
+    })
+  })
+})

--- a/app/assessmentFromCrn/post.controller.test.js
+++ b/app/assessmentFromCrn/post.controller.test.js
@@ -55,7 +55,7 @@ describe('POST: Start an assessment', () => {
         user,
       }
 
-      const apiResponse = [false, { status: 401 }]
+      const apiResponse = [false, { status: 401, reason: 'OASYS_PERMISSION' }]
 
       assessmentSupervision.mockResolvedValue(apiResponse)
 
@@ -77,7 +77,7 @@ describe('POST: Start an assessment', () => {
         user,
       }
 
-      const apiResponse = [false, { status: 400 }]
+      const apiResponse = [false, { status: 400, reason: 'DUPLICATE_OFFENDER_RECORD' }]
 
       assessmentSupervision.mockResolvedValue(apiResponse)
 
@@ -129,7 +129,7 @@ describe('POST: Start an assessment', () => {
         user,
       }
 
-      const apiResponse = [false, { status: 401 }]
+      const apiResponse = [false, { status: 401, reason: 'OASYS_PERMISSION' }]
 
       assessmentSupervision.mockResolvedValue(apiResponse)
 
@@ -151,7 +151,7 @@ describe('POST: Start an assessment', () => {
         user,
       }
 
-      const apiResponse = [false, { status: 400 }]
+      const apiResponse = [false, { status: 400, reason: 'DUPLICATE_OFFENDER_RECORD' }]
 
       assessmentSupervision.mockResolvedValue(apiResponse)
 

--- a/app/assessmentFromCrn/post.controller.test.js
+++ b/app/assessmentFromCrn/post.controller.test.js
@@ -82,10 +82,6 @@ describe('POST: Start an assessment', () => {
         {
           status: 400,
           reason: 'DUPLICATE_OFFENDER_RECORD',
-          offenderContext: {
-            name: 'Alan Grant',
-            pnc: '1234/123456A',
-          },
         },
       ]
 
@@ -94,7 +90,7 @@ describe('POST: Start an assessment', () => {
       await middleware(req, res)
 
       const theError = new Error(
-        'Alan Grant is showing as a possible duplicate record under USER_AREA PNC 1234/123456A Log into OASys to manage the duplication. If you need help, contact the OASys Application Support team',
+        'The offender is showing as a possible duplicate record under USER_AREA. Log into OASys to manage the duplication. If you need help, contact the OASys Application Support team',
       )
       expect(res.render).toHaveBeenCalledWith('app/error', { error: theError })
     })
@@ -165,10 +161,6 @@ describe('POST: Start an assessment', () => {
         {
           status: 400,
           reason: 'DUPLICATE_OFFENDER_RECORD',
-          offenderContext: {
-            name: 'Alan Grant',
-            pnc: '1234/123456A',
-          },
         },
       ]
 
@@ -177,7 +169,7 @@ describe('POST: Start an assessment', () => {
       await middleware(req, res)
 
       const theError = new Error(
-        'Alan Grant is showing as a possible duplicate record under USER_AREA PNC 1234/123456A Log into OASys to manage the duplication. If you need help, contact the OASys Application Support team',
+        'The offender is showing as a possible duplicate record under USER_AREA. Log into OASys to manage the duplication. If you need help, contact the OASys Application Support team',
       )
       expect(res.render).toHaveBeenCalledWith('app/error', { error: theError })
     })

--- a/app/assessmentFromCrn/post.controller.test.js
+++ b/app/assessmentFromCrn/post.controller.test.js
@@ -93,7 +93,6 @@ describe('POST: Start an assessment', () => {
 
       await middleware(req, res)
 
-      // These undefined values will need updating when we decide how to handle retrieving user details on error
       const theError = new Error(
         'Alan Grant is showing as a possible duplicate record under USER_AREA PNC 1234/123456A Log into OASys to manage the duplication. If you need help, contact the OASys Application Support team',
       )
@@ -177,7 +176,6 @@ describe('POST: Start an assessment', () => {
 
       await middleware(req, res)
 
-      // These undefined values will need updating when we decide how to handle retrieving user details on error
       const theError = new Error(
         'Alan Grant is showing as a possible duplicate record under USER_AREA PNC 1234/123456A Log into OASys to manage the duplication. If you need help, contact the OASys Application Support team',
       )

--- a/app/assessmentFromCrn/post.controller.test.js
+++ b/app/assessmentFromCrn/post.controller.test.js
@@ -77,7 +77,17 @@ describe('POST: Start an assessment', () => {
         user,
       }
 
-      const apiResponse = [false, { status: 400, reason: 'DUPLICATE_OFFENDER_RECORD' }]
+      const apiResponse = [
+        false,
+        {
+          status: 400,
+          reason: 'DUPLICATE_OFFENDER_RECORD',
+          offenderContext: {
+            name: 'Alan Grant',
+            pnc: '1234/123456A',
+          },
+        },
+      ]
 
       assessmentSupervision.mockResolvedValue(apiResponse)
 
@@ -85,7 +95,7 @@ describe('POST: Start an assessment', () => {
 
       // These undefined values will need updating when we decide how to handle retrieving user details on error
       const theError = new Error(
-        `${undefined} is showing as a possible duplicate record under USER_AREA PNC ${undefined} Log into OASys to manage the duplication. If you need help, contact the OASys Application Support team`,
+        'Alan Grant is showing as a possible duplicate record under USER_AREA PNC 1234/123456A Log into OASys to manage the duplication. If you need help, contact the OASys Application Support team',
       )
       expect(res.render).toHaveBeenCalledWith('app/error', { error: theError })
     })
@@ -151,7 +161,17 @@ describe('POST: Start an assessment', () => {
         user,
       }
 
-      const apiResponse = [false, { status: 400, reason: 'DUPLICATE_OFFENDER_RECORD' }]
+      const apiResponse = [
+        false,
+        {
+          status: 400,
+          reason: 'DUPLICATE_OFFENDER_RECORD',
+          offenderContext: {
+            name: 'Alan Grant',
+            pnc: '1234/123456A',
+          },
+        },
+      ]
 
       assessmentSupervision.mockResolvedValue(apiResponse)
 
@@ -159,7 +179,7 @@ describe('POST: Start an assessment', () => {
 
       // These undefined values will need updating when we decide how to handle retrieving user details on error
       const theError = new Error(
-        `${undefined} is showing as a possible duplicate record under USER_AREA PNC ${undefined} Log into OASys to manage the duplication. If you need help, contact the OASys Application Support team`,
+        'Alan Grant is showing as a possible duplicate record under USER_AREA PNC 1234/123456A Log into OASys to manage the duplication. If you need help, contact the OASys Application Support team',
       )
       expect(res.render).toHaveBeenCalledWith('app/error', { error: theError })
     })

--- a/app/error.njk
+++ b/app/error.njk
@@ -9,11 +9,13 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
-        {{ heading | default("Oh dear!") }}
+        {{ heading | default("There is a problem with the service") }}
       </h1>
+      {% if subHeading %}
       <h3 class="govuk-heading-m">
-        {{ subHeading | default("Something went wrong") }}
+        {{ subHeading }}
       <h3>
+      {% endif %}
       <p class="govuk-body">
       {% if showDetailedErrors %}
         {% if error %}

--- a/app/router.js
+++ b/app/router.js
@@ -177,9 +177,9 @@ module.exports = app => {
   app.post('/psr-from-court', startPsrFromForm)
   app.post('/psr-from-court/:courtCode/case/:caseNumber', startPsrFromCourt)
 
-  app.get('/assessment-from-delius', assessmentFromCrn())
+  app.get('/assessment-from-delius', assessmentFromCrn)
   app.post('/assessment-from-delius', startAssessmentFromForm())
-  app.post('/assessment-from-delius/:assessmentType/crn/:crn/event/:deliusEventId', startAssessmentFromCrn)
+  app.post('/assessment-from-delius/:assessmentType/crn/:crn/event/:deliusEventId', startAssessmentFromCrn())
 
   app.use((error, req, res, next) =>
     res.render('app/error', {

--- a/app/router.js
+++ b/app/router.js
@@ -177,8 +177,8 @@ module.exports = app => {
   app.post('/psr-from-court', startPsrFromForm)
   app.post('/psr-from-court/:courtCode/case/:caseNumber', startPsrFromCourt)
 
-  app.get('/assessment-from-delius', assessmentFromCrn)
-  app.post('/assessment-from-delius', startAssessmentFromForm)
+  app.get('/assessment-from-delius', assessmentFromCrn())
+  app.post('/assessment-from-delius', startAssessmentFromForm())
   app.post('/assessment-from-delius/:assessmentType/crn/:crn/event/:deliusEventId', startAssessmentFromCrn)
 
   app.use((error, req, res, next) =>

--- a/app/summary/post.controller.js
+++ b/app/summary/post.controller.js
@@ -3,6 +3,14 @@ const { logger } = require('../../common/logging/logger')
 const { displayOverview } = require('./get.controller')
 const { postCompleteAssessment } = require('../../common/data/hmppsAssessmentApi')
 
+const getErrorMessage = reason => {
+  if (reason === 'OASYS_PERMISSION') {
+    return 'You do not have permission to complete this type of assessment. Speak to your manager and ask them to request a change to your level of authorisation.'
+  }
+
+  return 'Something went wrong'
+}
+
 const completeAssessment = async (req, res) => {
   const {
     params: { assessmentId },
@@ -10,16 +18,14 @@ const completeAssessment = async (req, res) => {
   } = req
 
   try {
-    const [ok] = await postCompleteAssessment(assessmentId, user?.token, user?.id)
+    const [ok, response] = await postCompleteAssessment(assessmentId, user?.token, user?.id)
 
-    if (ok) {
-      res.locals.hideOffenderDetails = true
-      return res.render(`${__dirname}/success`, { offenderName: res.locals.offenderDetails.name })
+    if (!ok) {
+      return res.render('app/error', { error: new Error(getErrorMessage(response.reason)) })
     }
-    res.locals.assessmentCompletedMessage = 'There was a problem marking the assessment as complete'
-    res.locals.assessmentCompletedStatus = 'warning'
 
-    return displayOverview(req, res)
+    res.locals.hideOffenderDetails = true
+    return res.render(`${__dirname}/success`, { offenderName: res.locals.offenderDetails.name })
   } catch (error) {
     logger.error(`Could not complete assessment ${assessmentId}, error: ${error}`)
     return res.render('app/error', { error })

--- a/app/summary/post.controller.js
+++ b/app/summary/post.controller.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-param-reassign */
 const { logger } = require('../../common/logging/logger')
-const { displayOverview } = require('./get.controller')
 const { postCompleteAssessment } = require('../../common/data/hmppsAssessmentApi')
 
 const getErrorMessage = reason => {

--- a/app/summary/post.controller.test.js
+++ b/app/summary/post.controller.test.js
@@ -38,4 +38,15 @@ describe('display complete assessment page', () => {
 
     expect(res.render).toHaveBeenCalledWith(`${__dirname}/success`, { offenderName: 'Fred Smith' })
   })
+
+  it('renders an error when the user does not have permission to update the assessment', async () => {
+    postCompleteAssessment.mockResolvedValue([false, { status: 403, reason: 'OASYS_PERMISSION' }])
+
+    await completeAssessment(req, res)
+
+    const theError = new Error(
+      'You do not have permission to complete this type of assessment. Speak to your manager and ask them to request a change to your level of authorisation.',
+    )
+    expect(res.render).toHaveBeenCalledWith('app/error', { error: theError })
+  })
 })


### PR DESCRIPTION
## Context

We require additional details for the following scenarios

- Failure to create an assessment because of insufficient user permissions
- Failure to create an assessment because an offender record already exists

## Considerations

For this PR the handling of these errors is done in the controller to avoid a bigger rework of the assessments client, this is something we can explore at a later date if/when similar is introduced for other parts of the applications

There is also a requirement to show the offender details as part of the error message, this has been intentionally missed as to tackle in a subsequent PR - still need to figure this one out 🤔

Requires [PR 177 of HMPPS Assessments API](https://github.com/ministryofjustice/hmpps-assessments-api/pull/177)