### PR TITLE
Increase resources available for docker image when running Cypress tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
     docker:
       - image: circleci/node:14-buster-browsers
       - image: circleci/redis:buster
-    resource_class: large
+    resource_class: xlarge
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
Increases size of docker resource being used to run Cypress in CI, as per what some other teams have done (https://github.com/ministryofjustice/prisonstaffhub for example).

Hopefully this will lead to more reliability when running the tests. 