### PR TITLE
Fix handling of 400 and 403 errors

### DIFF
--- a/app/assessmentFromCrn/post.controller.js
+++ b/app/assessmentFromCrn/post.controller.js
@@ -17,9 +17,8 @@ const startAssessment = async (crn, deliusEventId, assessmentType, user, res) =>
     const [ok, response] = await assessmentSupervision({ crn, deliusEventId, assessmentType }, user?.token, user?.id)
 
     if (!ok) {
-      // get offender details?
       return res.render('app/error', {
-        error: new Error(getErrorMessageFor(response.reason, user)),
+        subHeading: getErrorMessageFor(response.reason, user),
       })
     }
 
@@ -29,20 +28,16 @@ const startAssessment = async (crn, deliusEventId, assessmentType, user, res) =>
   }
 }
 
-const createStartAssessmentFromCrnMiddleware = () => {
-  return function startAssessmentFromCrn({ params: { crn, deliusEventId, assessmentType }, user }, res) {
-    return startAssessment(crn, deliusEventId, assessmentType, user, res)
-  }
+const startAssessmentFromCrn = ({ params: { crn, deliusEventId, assessmentType }, user }, res) => {
+  return startAssessment(crn, deliusEventId, assessmentType, user, res)
 }
 
-const createStartAssessmentFromFormMiddleware = () => {
-  return function startAssessmentFromForm({ body, user }, res) {
-    const { crn, deliusEventId, assessmentType } = body
-    return startAssessment(crn, deliusEventId, assessmentType, user, res)
-  }
+const startAssessmentFromForm = ({ body, user }, res) => {
+  const { crn, deliusEventId, assessmentType } = body
+  return startAssessment(crn, deliusEventId, assessmentType, user, res)
 }
 
 module.exports = {
-  startAssessmentFromCrn: createStartAssessmentFromCrnMiddleware,
-  startAssessmentFromForm: createStartAssessmentFromFormMiddleware,
+  startAssessmentFromCrn,
+  startAssessmentFromForm,
 }

--- a/app/assessmentFromCrn/post.controller.test.js
+++ b/app/assessmentFromCrn/post.controller.test.js
@@ -18,8 +18,6 @@ describe('POST: Start an assessment', () => {
   }
 
   describe('from CRN', () => {
-    const middleware = startAssessmentFromCrn()
-
     beforeEach(() => {
       assessmentSupervision.mockReset()
       res.redirect.mockReset()
@@ -40,7 +38,7 @@ describe('POST: Start an assessment', () => {
 
       assessmentSupervision.mockResolvedValue(apiResponse)
 
-      await middleware(req, res)
+      await startAssessmentFromCrn(req, res)
 
       expect(res.redirect).toHaveBeenCalledWith('/ASSESSMENT_UUID/questionGroup/pre_sentence_assessment/summary')
     })
@@ -59,12 +57,12 @@ describe('POST: Start an assessment', () => {
 
       assessmentSupervision.mockResolvedValue(apiResponse)
 
-      await middleware(req, res)
+      await startAssessmentFromCrn(req, res)
 
-      const theError = new Error(
-        'You do not have permission to complete this type of assessment. Speak to your manager and ask them to request a change to your level of authorisation.',
-      )
-      expect(res.render).toHaveBeenCalledWith('app/error', { error: theError })
+      const theError =
+        'You do not have permission to complete this type of assessment. Speak to your manager and ask them to request a change to your level of authorisation.'
+
+      expect(res.render).toHaveBeenCalledWith('app/error', { subHeading: theError })
     })
 
     it('renders an error when attempting to create a duplicate assessment', async () => {
@@ -87,18 +85,16 @@ describe('POST: Start an assessment', () => {
 
       assessmentSupervision.mockResolvedValue(apiResponse)
 
-      await middleware(req, res)
+      await startAssessmentFromCrn(req, res)
 
-      const theError = new Error(
-        'The offender is showing as a possible duplicate record under USER_AREA. Log into OASys to manage the duplication. If you need help, contact the OASys Application Support team',
-      )
-      expect(res.render).toHaveBeenCalledWith('app/error', { error: theError })
+      const theError =
+        'The offender is showing as a possible duplicate record under USER_AREA. Log into OASys to manage the duplication. If you need help, contact the OASys Application Support team'
+
+      expect(res.render).toHaveBeenCalledWith('app/error', { subHeading: theError })
     })
   })
 
   describe('from form', () => {
-    const middleware = startAssessmentFromForm()
-
     beforeEach(() => {
       assessmentSupervision.mockReset()
       res.redirect.mockReset()
@@ -119,7 +115,7 @@ describe('POST: Start an assessment', () => {
 
       assessmentSupervision.mockResolvedValue(apiResponse)
 
-      await middleware(req, res)
+      await startAssessmentFromForm(req, res)
 
       expect(res.redirect).toHaveBeenCalledWith('/ASSESSMENT_UUID/questionGroup/pre_sentence_assessment/summary')
     })
@@ -138,12 +134,12 @@ describe('POST: Start an assessment', () => {
 
       assessmentSupervision.mockResolvedValue(apiResponse)
 
-      await middleware(req, res)
+      await startAssessmentFromForm(req, res)
 
-      const theError = new Error(
-        'You do not have permission to complete this type of assessment. Speak to your manager and ask them to request a change to your level of authorisation.',
-      )
-      expect(res.render).toHaveBeenCalledWith('app/error', { error: theError })
+      const theError =
+        'You do not have permission to complete this type of assessment. Speak to your manager and ask them to request a change to your level of authorisation.'
+
+      expect(res.render).toHaveBeenCalledWith('app/error', { subHeading: theError })
     })
 
     it('renders an error when attempting to create a duplicate assessment', async () => {
@@ -166,12 +162,12 @@ describe('POST: Start an assessment', () => {
 
       assessmentSupervision.mockResolvedValue(apiResponse)
 
-      await middleware(req, res)
+      await startAssessmentFromForm(req, res)
 
-      const theError = new Error(
-        'The offender is showing as a possible duplicate record under USER_AREA. Log into OASys to manage the duplication. If you need help, contact the OASys Application Support team',
-      )
-      expect(res.render).toHaveBeenCalledWith('app/error', { error: theError })
+      const theError =
+        'The offender is showing as a possible duplicate record under USER_AREA. Log into OASys to manage the duplication. If you need help, contact the OASys Application Support team'
+
+      expect(res.render).toHaveBeenCalledWith('app/error', { subHeading: theError })
     })
   })
 })

--- a/app/psrFromCourt/post.controller.js
+++ b/app/psrFromCourt/post.controller.js
@@ -1,25 +1,42 @@
 // const { logger } = require('../../common/logging/logger')
 const { assessmentSupervision } = require('../../common/data/hmppsAssessmentApi')
 
+const getErrorMessageFor = (reason, user) => {
+  if (reason === 'OASYS_PERMISSION') {
+    return 'You do not have permission to complete this type of assessment. Speak to your manager and ask them to request a change to your level of authorisation.'
+  }
+  if (reason === 'DUPLICATE_OFFENDER_RECORD') {
+    return `The offender is showing as a possible duplicate record under ${user.areaName}. Log into OASys to manage the duplication. If you need help, contact the OASys Application Support team`
+  }
+
+  return 'Something went wrong' // Unhandled exception
+}
+
+const startPsr = async (courtCode, caseNumber, user, res) => {
+  try {
+    // eslint-disable-next-line no-unused-vars
+    const [ok, response] = await assessmentSupervision({ courtCode, caseNumber }, user?.token, user?.id)
+
+    if (!ok) {
+      return res.render('app/error', {
+        subHeading: getErrorMessageFor(response.reason, user),
+      })
+    }
+
+    return res.redirect(`/${response.assessmentUuid}/questionGroup/pre_sentence_assessment/summary`)
+  } catch (error) {
+    return res.render('app/error', { error })
+  }
+}
+
 const startPsrFromCourt = ({ params: { courtCode, caseNumber }, user }, res) => {
-  return startPsr(courtCode, caseNumber, user?.token, user?.id, res)
+  return startPsr(courtCode, caseNumber, user, res)
 }
 
 const startPsrFromForm = ({ body, user }, res) => {
   const { courtCode, caseNumber } = body
 
-  return startPsr(courtCode, caseNumber, user?.token, user?.id, res)
-}
-
-const startPsr = async (courtCode, caseNumber, authorisationToken, userId, res) => {
-  try {
-    // eslint-disable-next-line no-unused-vars
-    const [ok, assessment] = await assessmentSupervision({ courtCode, caseNumber }, authorisationToken, userId)
-
-    return res.redirect(`/${assessment.assessmentUuid}/questionGroup/pre_sentence_assessment/summary`)
-  } catch (error) {
-    return res.render('app/error', { error })
-  }
+  return startPsr(courtCode, caseNumber, user, res)
 }
 
 module.exports = {

--- a/app/questionGroup/post.controller.js
+++ b/app/questionGroup/post.controller.js
@@ -35,7 +35,7 @@ const saveQuestionGroup = async (req, res) => {
         req.errorSummary = errorSummary
         return displayQuestionGroup(req, res)
       }
-      return res.render('app/error', { error: new Error(getErrorMessage(response.reason)) })
+      return res.render('app/error', { subHeading: getErrorMessage(response.reason) })
     }
 
     return res.redirect(`/${assessmentId}/questiongroup/${res.locals.navigation.next.url}`)

--- a/app/questionGroup/post.controller.test.js
+++ b/app/questionGroup/post.controller.test.js
@@ -115,10 +115,10 @@ describe('post answers', () => {
 
     await saveQuestionGroup(req, res)
 
-    const theError = new Error(
-      'You do not have permission to complete this type of assessment. Speak to your manager and ask them to request a change to your level of authorisation.',
-    )
-    expect(res.render).toHaveBeenCalledWith('app/error', { error: theError })
+    const theError =
+      'You do not have permission to complete this type of assessment. Speak to your manager and ask them to request a change to your level of authorisation.'
+
+    expect(res.render).toHaveBeenCalledWith('app/error', { subHeading: theError })
   })
 
   it('should display an error if answer saving fails', async () => {

--- a/app/router.js
+++ b/app/router.js
@@ -178,8 +178,8 @@ module.exports = app => {
   app.post('/psr-from-court/:courtCode/case/:caseNumber', startPsrFromCourt)
 
   app.get('/assessment-from-delius', assessmentFromCrn)
-  app.post('/assessment-from-delius', startAssessmentFromForm())
-  app.post('/assessment-from-delius/:assessmentType/crn/:crn/event/:deliusEventId', startAssessmentFromCrn())
+  app.post('/assessment-from-delius', startAssessmentFromForm)
+  app.post('/assessment-from-delius/:assessmentType/crn/:crn/event/:deliusEventId', startAssessmentFromCrn)
 
   app.use((error, req, res, next) =>
     res.render('app/error', {

--- a/app/summary/post.controller.js
+++ b/app/summary/post.controller.js
@@ -20,7 +20,7 @@ const completeAssessment = async (req, res) => {
     const [ok, response] = await postCompleteAssessment(assessmentId, user?.token, user?.id)
 
     if (!ok) {
-      return res.render('app/error', { error: new Error(getErrorMessage(response.reason)) })
+      return res.render('app/error', { subHeading: getErrorMessage(response.reason) })
     }
 
     res.locals.hideOffenderDetails = true

--- a/app/summary/post.controller.test.js
+++ b/app/summary/post.controller.test.js
@@ -29,6 +29,7 @@ describe('display complete assessment page', () => {
   beforeEach(() => {
     assessmentEpisodes = JSON.parse(JSON.stringify(assessmentEpisodesJson))
     postCompleteAssessment.mockReset()
+    res.render.mockReset()
   })
 
   it('should render the page with the correct structure', async () => {
@@ -44,9 +45,9 @@ describe('display complete assessment page', () => {
 
     await completeAssessment(req, res)
 
-    const theError = new Error(
-      'You do not have permission to complete this type of assessment. Speak to your manager and ask them to request a change to your level of authorisation.',
-    )
-    expect(res.render).toHaveBeenCalledWith('app/error', { error: theError })
+    const theError =
+      'You do not have permission to complete this type of assessment. Speak to your manager and ask them to request a change to your level of authorisation.'
+
+    expect(res.render).toHaveBeenCalledWith('app/error', { subHeading: theError })
   })
 })

--- a/common/data/hmppsAssessmentApi.js
+++ b/common/data/hmppsAssessmentApi.js
@@ -111,7 +111,7 @@ const action = async (agent, authorisationToken, userId) => {
       })
   } catch (error) {
     const { status, response } = error
-    if (status === 422) {
+    if (status === 400 || status === 403 || status === 422) {
       // unprocessable entity
       return [false, response.body]
     }

--- a/common/data/hmppsAssessmentApi.js
+++ b/common/data/hmppsAssessmentApi.js
@@ -112,7 +112,6 @@ const action = async (agent, authorisationToken, userId) => {
   } catch (error) {
     const { status, response } = error
     if (status === 400 || status === 403 || status === 422) {
-      // unprocessable entity
       return [false, response.body]
     }
 


### PR DESCRIPTION
- Move functional error messages to subHeading
- Handle 400/403 errors in HMPPS Assessment API Client
- Remove redundent wrapper around assessment from CRN middleware