### PR TITLE
Fix area selection validation when user has single area

### DIFF
--- a/common/middleware/area-selection.js
+++ b/common/middleware/area-selection.js
@@ -11,6 +11,8 @@ const checkUserHasAreaSelected = overrideUrl => async (req, res, next) => {
       const { regions } = await getUserProfile(user.oasysUserCode, apiToken)
       if (regions.length === 1) {
         await cacheUserDetailsWithRegion(user.id, regions[0].code, regions[0].name)
+        req.session.regions = regions
+        req.session.save()
       } else {
         req.session.regions = regions
         req.session.redirectUrl = overrideUrl || req.originalUrl


### PR DESCRIPTION
## Context

Fixes a bug where regions were not saved in the session when the user had a single area, this is unlikely to happen as the user would never be presented the area selection page as part of the usual flow - but is technically still possible if they were to navigate to the area selection page manually
