### PR TITLE
Remove flash from passport config

### DIFF
--- a/common/middleware/auth.js
+++ b/common/middleware/auth.js
@@ -114,7 +114,6 @@ const handleLoginCallback = () => {
     passport.authenticate('oauth2', {
       successReturnToOrRedirect: req.session.returnUrl || '/',
       failureRedirect: '/login',
-      failureFlash: true,
     })(req, res, next)
   }
 }

--- a/common/middleware/auth.test.js
+++ b/common/middleware/auth.test.js
@@ -234,7 +234,6 @@ describe('Auth', () => {
       expect(passport.authenticate).toHaveBeenCalledWith('oauth2', {
         successReturnToOrRedirect: req.session.returnUrl,
         failureRedirect: '/login',
-        failureFlash: true,
       })
 
       expect(mockPassportAuthenticateMiddleware).toHaveBeenCalledWith(req, res, next)


### PR DESCRIPTION
We no longer use connect flash - this PR removes passport configuration related to it