### PR TITLE
Fix AssessmentFromCRN request DTO

### DIFF
--- a/app/assessmentFromCrn/index.njk
+++ b/app/assessmentFromCrn/index.njk
@@ -22,9 +22,10 @@
           classes: 'govuk-input--width-20'
       }) }}
       {{ govukInput({
-          id: 'assessmentType',
-          name: 'assessmentType',
-          label: { text: 'Assessment Type', isPageHeading: false },
+          id: 'assessmentSchemaCode',
+          name: 'assessmentSchemaCode',
+          label: { text: 'Assessment Code', isPageHeading: false },
+          hint: { text: 'For example "ROSH" or "RSR"'},
           classes: 'govuk-input--width-20'
       }) }}
       {{ govukButton({

--- a/app/assessmentFromCrn/post.controller.js
+++ b/app/assessmentFromCrn/post.controller.js
@@ -11,10 +11,14 @@ const getErrorMessageFor = (reason, user) => {
   return 'Something went wrong' // Unhandled exception
 }
 
-const startAssessment = async (crn, deliusEventId, assessmentType, user, res) => {
+const startAssessment = async (crn, deliusEventId, assessmentSchemaCode, user, res) => {
   try {
     // eslint-disable-next-line no-unused-vars
-    const [ok, response] = await assessmentSupervision({ crn, deliusEventId, assessmentType }, user?.token, user?.id)
+    const [ok, response] = await assessmentSupervision(
+      { crn, deliusEventId, assessmentSchemaCode },
+      user?.token,
+      user?.id,
+    )
 
     if (!ok) {
       return res.render('app/error', {
@@ -28,13 +32,13 @@ const startAssessment = async (crn, deliusEventId, assessmentType, user, res) =>
   }
 }
 
-const startAssessmentFromCrn = ({ params: { crn, deliusEventId, assessmentType }, user }, res) => {
-  return startAssessment(crn, deliusEventId, assessmentType, user, res)
+const startAssessmentFromCrn = ({ params: { crn, deliusEventId, assessmentSchemaCode }, user }, res) => {
+  return startAssessment(crn, deliusEventId, assessmentSchemaCode, user, res)
 }
 
 const startAssessmentFromForm = ({ body, user }, res) => {
-  const { crn, deliusEventId, assessmentType } = body
-  return startAssessment(crn, deliusEventId, assessmentType, user, res)
+  const { crn, deliusEventId, assessmentSchemaCode } = body
+  return startAssessment(crn, deliusEventId, assessmentSchemaCode, user, res)
 }
 
 module.exports = {

--- a/app/assessmentFromCrn/post.controller.test.js
+++ b/app/assessmentFromCrn/post.controller.test.js
@@ -29,7 +29,7 @@ describe('POST: Start an assessment', () => {
         params: {
           crn: 'CRN',
           deliusEventId: 'DELIUS_EVENT_ID',
-          assessmentType: 'ASSESSMENT_TYPE',
+          assessmentSchemaCode: 'ASSESSMENT_TYPE',
         },
         user,
       }
@@ -48,7 +48,7 @@ describe('POST: Start an assessment', () => {
         params: {
           crn: 'CRN',
           deliusEventId: 'DELIUS_EVENT_ID',
-          assessmentType: 'ASSESSMENT_TYPE',
+          assessmentSchemaCode: 'ASSESSMENT_TYPE',
         },
         user,
       }
@@ -70,7 +70,7 @@ describe('POST: Start an assessment', () => {
         params: {
           crn: 'CRN',
           deliusEventId: 'DELIUS_EVENT_ID',
-          assessmentType: 'ASSESSMENT_TYPE',
+          assessmentSchemaCode: 'ASSESSMENT_TYPE',
         },
         user,
       }
@@ -106,7 +106,7 @@ describe('POST: Start an assessment', () => {
         body: {
           crn: 'CRN',
           deliusEventId: 'DELIUS_EVENT_ID',
-          assessmentType: 'ASSESSMENT_TYPE',
+          assessmentSchemaCode: 'ASSESSMENT_TYPE',
         },
         user,
       }
@@ -125,7 +125,7 @@ describe('POST: Start an assessment', () => {
         body: {
           crn: 'CRN',
           deliusEventId: 'DELIUS_EVENT_ID',
-          assessmentType: 'ASSESSMENT_TYPE',
+          assessmentSchemaCode: 'ASSESSMENT_TYPE',
         },
         user,
       }
@@ -147,7 +147,7 @@ describe('POST: Start an assessment', () => {
         body: {
           crn: 'CRN',
           deliusEventId: 'DELIUS_EVENT_ID',
-          assessmentType: 'ASSESSMENT_TYPE',
+          assessmentSchemaCode: 'ASSESSMENT_TYPE',
         },
         user,
       }

--- a/app/router.js
+++ b/app/router.js
@@ -108,7 +108,7 @@ module.exports = app => {
   app.get('*', checkUserHasAreaSelected())
   app.get(`/:assessmentId/assessments`, getOffenderDetails, displayAssessmentsList)
 
-  app.get(`/:assessmentId/questiongroup/:assessmentType/summary`, getOffenderDetails, displayOverview)
+  app.get(`/:assessmentId/questiongroup/:assessmentSchemaCode/summary`, getOffenderDetails, displayOverview)
 
   app.get(
     `/:assessmentId/questiongroup/:groupId/:subgroup/:page`,
@@ -179,7 +179,7 @@ module.exports = app => {
 
   app.get('/assessment-from-delius', assessmentFromCrn)
   app.post('/assessment-from-delius', startAssessmentFromForm)
-  app.post('/assessment-from-delius/:assessmentType/crn/:crn/event/:deliusEventId', startAssessmentFromCrn)
+  app.post('/assessment-from-delius/:assessmentSchemaCode/crn/:crn/event/:deliusEventId', startAssessmentFromCrn)
 
   app.use((error, req, res, next) =>
     res.render('app/error', {

--- a/app/summary/get.controller.js
+++ b/app/summary/get.controller.js
@@ -5,11 +5,11 @@ const { getAssessmentSummary } = require('../../common/data/hmppsAssessmentApi')
 const { processReplacements } = require('../../common/utils/util')
 
 const displayOverview = async (
-  { params: { assessmentId, assessmentType }, errors = {}, errorSummary = null, user },
+  { params: { assessmentId, assessmentSchemaCode }, errors = {}, errorSummary = null, user },
   res,
 ) => {
   try {
-    let assessment = await grabAssessmentSummary(assessmentType, user?.token, user?.id)
+    let assessment = await grabAssessmentSummary(assessmentSchemaCode, user?.token, user?.id)
 
     assessment = processReplacements(assessment, res.locals.offenderDetails)
 
@@ -25,7 +25,7 @@ const displayOverview = async (
         items: [],
       }
       section.contents?.forEach((item, index) => {
-        const href = `/${assessmentId}/questiongroup/${assessmentType}/${sectionIndex}/${index}`
+        const href = `/${assessmentId}/questiongroup/${assessmentSchemaCode}/${sectionIndex}/${index}`
         const newItem = {
           text: item.title,
           href,
@@ -41,18 +41,18 @@ const displayOverview = async (
       assessmentId,
       summary,
       subheading: assessment.title,
-      groupId: assessmentType,
+      groupId: assessmentSchemaCode,
     })
   } catch (error) {
     return res.render('app/error', { error })
   }
 }
 
-const grabAssessmentSummary = (assessmentType, token, userId) => {
+const grabAssessmentSummary = (assessmentSchemaCode, token, userId) => {
   try {
-    return getAssessmentSummary(assessmentType, token, userId)
+    return getAssessmentSummary(assessmentSchemaCode, token, userId)
   } catch (error) {
-    logger.error(`Could not retrieve assessment summary for ${assessmentType}, error: ${error}`)
+    logger.error(`Could not retrieve assessment summary for ${assessmentSchemaCode}, error: ${error}`)
     throw error
   }
 }

--- a/app/summary/get.controller.test.js
+++ b/app/summary/get.controller.test.js
@@ -16,7 +16,7 @@ describe('display question group summary', () => {
     user,
     params: {
       assessmentId: 'test-assessment-id',
-      assessmentType: 'ROSH',
+      assessmentSchemaCode: 'ROSH',
     },
   }
   const res = {

--- a/common/data/hmppsAssessmentApi.js
+++ b/common/data/hmppsAssessmentApi.js
@@ -19,8 +19,8 @@ const getOffenderData = (uuid, authorisationToken, userId) => {
   return getData(path, authorisationToken, userId)
 }
 
-const getAssessmentQuestions = (assessmentType, authorisationToken, userId) => {
-  const path = `${url}/assessments/schema/${assessmentType}`
+const getAssessmentQuestions = (assessmentSchemaCode, authorisationToken, userId) => {
+  const path = `${url}/assessments/schema/${assessmentSchemaCode}`
   return getData(path, authorisationToken, userId)
 }
 
@@ -29,8 +29,8 @@ const getQuestionGroupSummary = (groupId, authorisationToken, userId) => {
   return getData(path, authorisationToken, userId)
 }
 
-const getAssessmentSummary = (assessmentType, authorisationToken, userId) => {
-  const path = `${url}/assessments/schema/${assessmentType}/summary`
+const getAssessmentSummary = (assessmentSchemaCode, authorisationToken, userId) => {
+  const path = `${url}/assessments/schema/${assessmentSchemaCode}/summary`
   return getData(path, authorisationToken, userId)
 }
 


### PR DESCRIPTION
## Context

This PR intends to fix and issue we're seeing in Dev where the `AssessmentFromCRN` fails due to switching over to `assessmentSchemaCode` on the `hmpps-assessments-api`

I have also renamed other usages where I be it to be appropriate

## Steps

**Expected**

- Navigate to `/assessment-from-delius`
- Fill out the form with a valid CRN and Assessment Schema Code
- Submit
- An assessment is created

**Actual**

- Navigate to `/assessment-from-delius`
- Fill out the form with a valid CRN and Assessment Schema Code
- Submit
- A `400` is returned from the API

**The error**
```
JSON parse error: Instantiation of [simple type, class uk.gov.justice.digital.assessments.api.CreateAssessmentDto] value failed for JSON property assessmentSchemaCode due to missing (therefore NULL) value for creator parameter assessmentSchemaCode which is a non-nullable type
```