### PR TITLE
Add support for no answers

### DIFF
--- a/app/addRow/fixtures/expected.json
+++ b/app/addRow/fixtures/expected.json
@@ -18,7 +18,7 @@
       "conditional": false,
       "referenceDataTargets": [],
       "answerSchemas": [],
-      "answer": null
+      "answer": ""
     },
     {
       "type": "question",
@@ -32,7 +32,7 @@
       "conditional": false,
       "referenceDataTargets": [],
       "answerSchemas": [],
-      "answer": null
+      "answer": ""
     },
     {
       "type": "question",
@@ -41,7 +41,7 @@
       "answerType": "freetext",
       "questionText": "Child's name",
       "validation": "{\"mandatory\":{\"errorMessage\":\"Enter the name\",\"errorSummary\":\"You must enter a name\"}}",
-      "answer": null
+      "answer": ""
     },
     {
       "type": "question",
@@ -49,7 +49,7 @@
       "questionCode": "129.2",
       "answerType": "freetext",
       "questionText": "Child's age",
-      "answer": null
+      "answer": ""
     },
     {
       "type": "question",
@@ -57,7 +57,7 @@
       "questionCode": "129.3",
       "answerType": "textarea",
       "questionText": "Child's address",
-      "answer": null
+      "answer": ""
     },
     {
       "type": "question",
@@ -65,7 +65,7 @@
       "questionCode": "129.4",
       "answerType": "date",
       "questionText": "Date of birth",
-      "answer": null
+      "answer": ""
     },
     {
       "type": "question",

--- a/app/editRow/fixtures/expected.json
+++ b/app/editRow/fixtures/expected.json
@@ -18,7 +18,7 @@
       "conditional": false,
       "referenceDataTargets": [],
       "answerSchemas": [],
-      "answer": null
+      "answer": ""
     },
     {
       "type": "question",
@@ -32,7 +32,7 @@
       "conditional": false,
       "referenceDataTargets": [],
       "answerSchemas": [],
-      "answer": null
+      "answer": ""
     },
     {
       "type": "question",
@@ -41,7 +41,7 @@
       "answerType": "freetext",
       "questionText": "Child's name",
       "validation": "{\"mandatory\":{\"errorMessage\":\"Enter the name\",\"errorSummary\":\"You must enter a name\"}}",
-      "answer": null
+      "answer": ""
     },
     {
       "type": "question",
@@ -49,7 +49,7 @@
       "questionCode": "129.2",
       "answerType": "freetext",
       "questionText": "Child's age",
-      "answer": null
+      "answer": ""
     },
     {
       "type": "question",
@@ -57,7 +57,7 @@
       "questionCode": "129.3",
       "answerType": "textarea",
       "questionText": "Child's address",
-      "answer": null
+      "answer": ""
     },
     {
       "type": "question",
@@ -65,7 +65,7 @@
       "questionCode": "129.4",
       "answerType": "date",
       "questionText": "Date of birth",
-      "answer": null
+      "answer": ""
     },
     {
       "type": "question",

--- a/app/questionGroup/fixtures/expected.json
+++ b/app/questionGroup/fixtures/expected.json
@@ -13,7 +13,7 @@
       "displayOrder": "1",
       "mandatory": "yes",
       "answerSchemas": [],
-      "answer": null,
+      "answer": "",
       "validation": "{\"mandatory\":{\"errorMessage\":\"Enter the forename\",\"errorSummary\":\"You must enter a forename\"}}"
     },
     {
@@ -25,7 +25,7 @@
       "displayOrder": "2",
       "mandatory": "yes",
       "answerSchemas": [],
-      "answer": null,
+      "answer": "",
       "validation": "{\"mandatory\":{\"errorMessage\":\"Enter the surname\",\"errorSummary\":\"You must enter a surname\"}}"
     },
     {
@@ -40,7 +40,7 @@
       "conditional": false,
       "referenceDataTargets": [],
       "answerSchemas": [],
-      "answer": null
+      "answer": ""
     },
     {
       "type": "TableQuestionDto",
@@ -61,7 +61,7 @@
           "conditional": false,
           "referenceDataTargets": [],
           "answerSchemas": [],
-          "answer": null
+          "answer": ""
         },
         {
           "type": "question",
@@ -75,7 +75,7 @@
           "conditional": false,
           "referenceDataTargets": [],
           "answerSchemas": [],
-          "answer": null
+          "answer": ""
         },
         {
           "type": "question",
@@ -84,7 +84,7 @@
           "answerType": "freetext",
           "questionText": "Child's name",
           "validation": "{\"mandatory\":{\"errorMessage\":\"Enter the name\",\"errorSummary\":\"You must enter a name\"}}",
-          "answer": null
+          "answer": ""
         },
         {
           "type": "question",
@@ -92,7 +92,7 @@
           "questionCode": "129.2",
           "answerType": "freetext",
           "questionText": "Child's age",
-          "answer": null
+          "answer": ""
         },
         {
           "type": "question",
@@ -100,7 +100,7 @@
           "questionCode": "129.3",
           "answerType": "textarea",
           "questionText": "Child's address",
-          "answer": null
+          "answer": ""
         },
         {
           "type": "question",
@@ -108,7 +108,7 @@
           "questionCode": "129.4",
           "answerType": "date",
           "questionText": "Date of birth",
-          "answer": null
+          "answer": ""
         },
         {
           "type": "question",
@@ -152,7 +152,7 @@
       "displayOrder": "3",
       "mandatory": "no",
       "answerSchemas": [],
-      "answer": null
+      "answer": ""
     },
     {
       "type": "question",
@@ -163,7 +163,7 @@
       "displayOrder": "4",
       "mandatory": "no",
       "answerSchemas": [],
-      "answer": null
+      "answer": ""
     },
     {
       "type": "question",
@@ -311,7 +311,7 @@
           "text": "Reform or rehabilitation"
         }
       ],
-      "answer": null
+      "answer": ""
     },
     {
       "type": "question",
@@ -323,7 +323,7 @@
       "mandatory": "no",
       "helpText": "Enter any other relevant information",
       "answerSchemas": [],
-      "answer": null
+      "answer": ""
     },
     {
       "type": "question",
@@ -425,7 +425,7 @@
       "mandatory": true,
       "conditional": true,
       "answerSchemas": [],
-      "answer": null,
+      "answer": "",
       "formClasses": "govuk-radios__conditional govuk-radios__conditional--no-indent govuk-radios__conditional--hidden",
       "isConditional": true,
       "attributes": [

--- a/app/questionGroup/get.controller.test.js
+++ b/app/questionGroup/get.controller.test.js
@@ -74,6 +74,21 @@ describe('display question group and answers', () => {
     expect(res.render).toHaveBeenCalledWith(`${__dirname}/index`, expectedWithAnswers)
   })
 
+  it('should default answers where not available', async () => {
+    const expectedWithAnswers = JSON.parse(JSON.stringify(expectedForThisTest))
+    expectedWithAnswers.questions[0].answer = ''
+    expectedWithAnswers.questions[1].answer = ''
+    getAnswers.mockReturnValueOnce({
+      answers: {
+        '11111111-1111-1111-1111-111111111201': [],
+        '11111111-1111-1111-1111-111111111202': [],
+      },
+    })
+
+    await displayQuestionGroup(req, res)
+    expect(res.render).toHaveBeenCalledWith(`${__dirname}/index`, expectedWithAnswers)
+  })
+
   it('should throw an error if it cannot retrieve answers', async () => {
     const theError = new Error('Answers error message')
     getAnswers.mockImplementation(() => {


### PR DESCRIPTION
## Background

This PR aims to fix a broken integration with the backend API where blank answers are no longer persisted. The tests were already built around null answer types - however these were (AFAIK) never supplied in Dev as the answers would always be persisted as `""` if they were not filled in.

## Intent

- Update GetQuestionGroups to provide default answers where non is available
- Update Tests and Fixtures

## Considerations

This PR sets a default for answers which is `""` as it would have previously been