### PR TITLE
ARN 522 show RSR predictor scores in the UI

### DIFF
--- a/app/predictorScores/get.controller.js
+++ b/app/predictorScores/get.controller.js
@@ -1,0 +1,22 @@
+const { getPredictorScoresForEpisode } = require('../../common/data/predictorScores')
+
+const formatPredictorScores = predictorScores => {
+  const [currentScores, ...historicalScores] = predictorScores
+  return {
+    currentScores,
+    historicalScores,
+  }
+}
+
+const displayPredictorScores = async ({ params: { episodeUuid } }, res) => {
+  try {
+    const predictorScores = await getPredictorScoresForEpisode(episodeUuid)
+    return res.render(`${__dirname}/index`, {
+      predictorScores: formatPredictorScores(predictorScores),
+    })
+  } catch (error) {
+    return res.render('app/error', { error })
+  }
+}
+
+module.exports = { displayPredictorScores }

--- a/app/predictorScores/get.controller.js
+++ b/app/predictorScores/get.controller.js
@@ -1,5 +1,6 @@
 const { format, parseISO } = require('date-fns')
 const { getPredictorScoresForEpisode } = require('../../common/data/predictorScores')
+const logger = require('../../common/logging/logger')
 
 const formatDate = dateString => {
   const date = parseISO(dateString)
@@ -62,6 +63,9 @@ const displayPredictorScores = async (req, res) => {
     const {
       params: { episodeUuid, assessmentType },
     } = req
+
+    logger.info(`Displaying predictor scores for episode: ${episodeUuid} of type: ${assessmentType}`)
+
     const predictorScores = await getPredictorScoresForEpisode(episodeUuid)
 
     const { previousPage } = req.session.navigation
@@ -74,6 +78,7 @@ const displayPredictorScores = async (req, res) => {
       subheading: getSubheadingFor(assessmentType),
       navigation: {
         previous: previousPage,
+        complete: { url: `/episode/${episodeUuid}/${assessmentType}/scores/complete` },
       },
     })
   } catch (error) {

--- a/app/predictorScores/get.controller.js
+++ b/app/predictorScores/get.controller.js
@@ -1,10 +1,23 @@
+const { format, parseISO } = require('date-fns')
 const { getPredictorScoresForEpisode } = require('../../common/data/predictorScores')
 
-const formatPredictorScores = predictorScores => {
+const formatDate = dateString => {
+  const date = parseISO(dateString)
+  const datePart = format(date, 'd MMM y')
+  const timePart = format(date, 'H:mm')
+  return `${datePart} at ${timePart}`
+}
+
+const formatPredictorScores = predictorScores => ({
+  ...predictorScores,
+  date: formatDate(predictorScores.date),
+})
+
+const splitPredictorScores = predictorScores => {
   const [currentScores, ...historicalScores] = predictorScores
   return {
-    currentScores,
-    historicalScores,
+    currentScores: formatPredictorScores(currentScores),
+    historicalScores: historicalScores.map(formatPredictorScores),
   }
 }
 
@@ -12,7 +25,7 @@ const displayPredictorScores = async ({ params: { episodeUuid } }, res) => {
   try {
     const predictorScores = await getPredictorScoresForEpisode(episodeUuid)
     return res.render(`${__dirname}/index`, {
-      predictorScores: formatPredictorScores(predictorScores),
+      predictorScores: splitPredictorScores(predictorScores),
     })
   } catch (error) {
     return res.render('app/error', { error })

--- a/app/predictorScores/get.controller.test.js
+++ b/app/predictorScores/get.controller.test.js
@@ -33,21 +33,21 @@ const predictorScores = [
 
 const formattedCurrentPredictorScore = {
   date: '23 Jul 2021 at 12:00',
-  scores: [
-    { type: 'RSR', level: 'HIGH', score: 11.34 },
-    { type: 'OSP/C', level: 'MEDIUM', score: 8.76 },
-    { type: 'OSP/I', level: 'LOW', score: 3.45 },
-  ],
+  scores: {
+    RSR: { type: 'RSR', level: 'HIGH', score: 11.34 },
+    OSPC: { type: 'OSP/C', level: 'MEDIUM', score: 8.76 },
+    OSPI: { type: 'OSP/I', level: 'LOW', score: 3.45 },
+  },
 }
 
 const formattedHistoricalPredictorScores = [
   {
     date: '22 Jul 2021 at 12:00',
-    scores: [
-      { type: 'RSR', level: 'HIGH', score: 11.34 },
-      { type: 'OSP/C', level: 'MEDIUM', score: 8.76 },
-      { type: 'OSP/I', level: 'LOW', score: 3.45 },
-    ],
+    scores: {
+      RSR: { type: 'RSR', level: 'HIGH', score: 11.34 },
+      OSPC: { type: 'OSP/C', level: 'MEDIUM', score: 8.76 },
+      OSPI: { type: 'OSP/I', level: 'LOW', score: 3.45 },
+    },
   },
 ]
 
@@ -55,6 +55,7 @@ describe('display predictor scores', () => {
   const req = {
     params: {
       episodeUuid: '22222222-2222-2222-2222-222222222222',
+      assessmentType: 'RSR',
     },
     session: {
       navigation: {
@@ -86,7 +87,7 @@ describe('display predictor scores', () => {
 
     expect(getPredictorScoresForEpisode).toHaveBeenCalledWith(episodeUuid)
     expect(res.render).toHaveBeenCalledWith(`${__dirname}/index`, {
-      assessmentType: 'PLACEHOLDER - Assessment Type',
+      subheading: 'Risk of Serious Recidivism (RSR) assessment',
       heading: "Bob Ross's scores",
       navigation: {
         previous: {
@@ -95,8 +96,8 @@ describe('display predictor scores', () => {
         },
       },
       predictorScores: {
-        currentScores: formattedCurrentPredictorScore,
-        historicalScores: formattedHistoricalPredictorScores,
+        current: formattedCurrentPredictorScore,
+        historical: formattedHistoricalPredictorScores,
       },
     })
   })

--- a/app/predictorScores/get.controller.test.js
+++ b/app/predictorScores/get.controller.test.js
@@ -94,6 +94,9 @@ describe('display predictor scores', () => {
           name: 'previous page',
           url: '/foo/bar',
         },
+        complete: {
+          url: '/episode/22222222-2222-2222-2222-222222222222/RSR/scores/complete',
+        },
       },
       predictorScores: {
         current: formattedCurrentPredictorScore,

--- a/app/predictorScores/get.controller.test.js
+++ b/app/predictorScores/get.controller.test.js
@@ -7,35 +7,47 @@ jest.mock('../../common/data/predictorScores', () => ({
 
 const episodeUuid = '22222222-2222-2222-2222-222222222222'
 
-const currentPredictorScore = {
-  date: '2021-07-23T12:00',
-  scores: [{ type: 'RSR', score: 'LOW' }],
-}
-
-const historicalPredictorScores = [
+const predictorScores = [
   {
-    date: '2021-07-22T12:00',
-    scores: [{ type: 'RSR', score: 'MEDIUM' }],
+    type: 'RSR',
+    scores: [
+      { level: 'HIGH', score: 11.34, isValid: true, date: '2021-07-23T12:00' },
+      { level: 'HIGH', score: 11.34, isValid: true, date: '2021-07-22T12:00' },
+    ],
   },
   {
-    date: '2021-07-21T12:00',
-    scores: [{ type: 'RSR', score: 'HIGH' }],
+    type: 'OSP/C',
+    scores: [
+      { level: 'MEDIUM', score: 8.76, isValid: true, date: '2021-07-23T12:00' },
+      { level: 'MEDIUM', score: 8.76, isValid: true, date: '2021-07-22T12:00' },
+    ],
+  },
+  {
+    type: 'OSP/I',
+    scores: [
+      { level: 'LOW', score: 3.45, isValid: true, date: '2021-07-23T12:00' },
+      { level: 'LOW', score: 3.45, isValid: true, date: '2021-07-22T12:00' },
+    ],
   },
 ]
 
 const formattedCurrentPredictorScore = {
   date: '23 Jul 2021 at 12:00',
-  scores: [{ type: 'RSR', score: 'LOW' }],
+  scores: [
+    { type: 'RSR', level: 'HIGH', score: 11.34 },
+    { type: 'OSP/C', level: 'MEDIUM', score: 8.76 },
+    { type: 'OSP/I', level: 'LOW', score: 3.45 },
+  ],
 }
 
 const formattedHistoricalPredictorScores = [
   {
     date: '22 Jul 2021 at 12:00',
-    scores: [{ type: 'RSR', score: 'MEDIUM' }],
-  },
-  {
-    date: '21 Jul 2021 at 12:00',
-    scores: [{ type: 'RSR', score: 'HIGH' }],
+    scores: [
+      { type: 'RSR', level: 'HIGH', score: 11.34 },
+      { type: 'OSP/C', level: 'MEDIUM', score: 8.76 },
+      { type: 'OSP/I', level: 'LOW', score: 3.45 },
+    ],
   },
 ]
 
@@ -44,10 +56,23 @@ describe('display predictor scores', () => {
     params: {
       episodeUuid: '22222222-2222-2222-2222-222222222222',
     },
+    session: {
+      navigation: {
+        previousPage: {
+          url: '/foo/bar',
+          name: 'previous page',
+        },
+      },
+    },
   }
   const res = {
     render: jest.fn(),
     redirect: jest.fn(),
+    locals: {
+      offenderDetails: {
+        name: 'Bob Ross',
+      },
+    },
   }
 
   beforeEach(() => {
@@ -55,12 +80,20 @@ describe('display predictor scores', () => {
   })
 
   it('displays predictor scores', async () => {
-    getPredictorScoresForEpisode.mockResolvedValue([currentPredictorScore, ...historicalPredictorScores])
+    getPredictorScoresForEpisode.mockResolvedValue(predictorScores)
 
     await displayPredictorScores(req, res)
 
     expect(getPredictorScoresForEpisode).toHaveBeenCalledWith(episodeUuid)
     expect(res.render).toHaveBeenCalledWith(`${__dirname}/index`, {
+      assessmentType: 'PLACEHOLDER - Assessment Type',
+      heading: "Bob Ross's scores",
+      navigation: {
+        previous: {
+          name: 'previous page',
+          url: '/foo/bar',
+        },
+      },
       predictorScores: {
         currentScores: formattedCurrentPredictorScore,
         historicalScores: formattedHistoricalPredictorScores,

--- a/app/predictorScores/get.controller.test.js
+++ b/app/predictorScores/get.controller.test.js
@@ -8,17 +8,33 @@ jest.mock('../../common/data/predictorScores', () => ({
 const episodeUuid = '22222222-2222-2222-2222-222222222222'
 
 const currentPredictorScore = {
-  date: '2021/07/23',
+  date: '2021-07-23T12:00',
   scores: [{ type: 'RSR', score: 'LOW' }],
 }
 
 const historicalPredictorScores = [
   {
-    date: '2021/07/22',
+    date: '2021-07-22T12:00',
     scores: [{ type: 'RSR', score: 'MEDIUM' }],
   },
   {
-    date: '2021/07/21',
+    date: '2021-07-21T12:00',
+    scores: [{ type: 'RSR', score: 'HIGH' }],
+  },
+]
+
+const formattedCurrentPredictorScore = {
+  date: '23 Jul 2021 at 12:00',
+  scores: [{ type: 'RSR', score: 'LOW' }],
+}
+
+const formattedHistoricalPredictorScores = [
+  {
+    date: '22 Jul 2021 at 12:00',
+    scores: [{ type: 'RSR', score: 'MEDIUM' }],
+  },
+  {
+    date: '21 Jul 2021 at 12:00',
     scores: [{ type: 'RSR', score: 'HIGH' }],
   },
 ]
@@ -46,8 +62,8 @@ describe('display predictor scores', () => {
     expect(getPredictorScoresForEpisode).toHaveBeenCalledWith(episodeUuid)
     expect(res.render).toHaveBeenCalledWith(`${__dirname}/index`, {
       predictorScores: {
-        currentScores: currentPredictorScore,
-        historicalScores: historicalPredictorScores,
+        currentScores: formattedCurrentPredictorScore,
+        historicalScores: formattedHistoricalPredictorScores,
       },
     })
   })

--- a/app/predictorScores/get.controller.test.js
+++ b/app/predictorScores/get.controller.test.js
@@ -1,0 +1,64 @@
+const { displayPredictorScores } = require('./get.controller')
+const { getPredictorScoresForEpisode } = require('../../common/data/predictorScores')
+
+jest.mock('../../common/data/predictorScores', () => ({
+  getPredictorScoresForEpisode: jest.fn(),
+}))
+
+const episodeUuid = '22222222-2222-2222-2222-222222222222'
+
+const currentPredictorScore = {
+  date: '2021/07/23',
+  scores: [{ type: 'RSR', score: 'LOW' }],
+}
+
+const historicalPredictorScores = [
+  {
+    date: '2021/07/22',
+    scores: [{ type: 'RSR', score: 'MEDIUM' }],
+  },
+  {
+    date: '2021/07/21',
+    scores: [{ type: 'RSR', score: 'HIGH' }],
+  },
+]
+
+describe('display predictor scores', () => {
+  const req = {
+    params: {
+      episodeUuid: '22222222-2222-2222-2222-222222222222',
+    },
+  }
+  const res = {
+    render: jest.fn(),
+    redirect: jest.fn(),
+  }
+
+  beforeEach(() => {
+    getPredictorScoresForEpisode.mockReset()
+  })
+
+  it('displays predictor scores', async () => {
+    getPredictorScoresForEpisode.mockResolvedValue([currentPredictorScore, ...historicalPredictorScores])
+
+    await displayPredictorScores(req, res)
+
+    expect(getPredictorScoresForEpisode).toHaveBeenCalledWith(episodeUuid)
+    expect(res.render).toHaveBeenCalledWith(`${__dirname}/index`, {
+      predictorScores: {
+        currentScores: currentPredictorScore,
+        historicalScores: historicalPredictorScores,
+      },
+    })
+  })
+
+  it('catches exceptions and renders the error page', async () => {
+    const theError = new Error('💥')
+    getPredictorScoresForEpisode.mockRejectedValue(theError)
+
+    await displayPredictorScores(req, res)
+
+    expect(getPredictorScoresForEpisode).toHaveBeenCalled()
+    expect(res.render).toHaveBeenCalledWith(`app/error`, { error: theError })
+  })
+})

--- a/app/predictorScores/index.njk
+++ b/app/predictorScores/index.njk
@@ -26,7 +26,7 @@
     </h1>
 
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
+        <div  id="predictor-scores"  class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <h2 class="govuk-heading-l">RSR score</h2>
@@ -129,7 +129,7 @@
                 </div>
             </div>
         </div>
-        <div class="govuk-grid-column-one-third">
+        <div id="predictor-scores-history" class="govuk-grid-column-one-third">
             <div class="govuk-body predictor-timeline__heading">
                 <h2 class="govuk-heading-l">Scores history</h2>
                 <a id="predictor-timeline__toggle-all" href="#" class="govuk-link">Open all</a>

--- a/app/predictorScores/index.njk
+++ b/app/predictorScores/index.njk
@@ -36,7 +36,23 @@
                             </span>
                         </summary>
                         <div class="govuk-details__text">
-                            PLACEHOLDER
+                            <h3 class="govuk-heading-s">What it shows</h3>
+                            <p>The probability of proven reoffending by an individual within 1 and 2 years. Three types of offence are covered:</p>
+                            <ul class="govuk-list govuk-list--bullet">
+                                <li>Serious Nonsexual Violence (SNSV)</li>
+                                <li>Contact Sexual (CS)</li>
+                                <li>Indecent Images of Children (IIOC)</li>
+                            </ul>
+                            <p>Each type has its own actuarial predictor, and the RSR is the sum of all three predictor scores. The CS and IIOC elements are only scored for individuals with a known history of sexual offending; for those without a history, the RSR score is simply the SNSV score. For men, the CS and IIOC elements are provided by the OASys Sexual Reoffending Predictor scores (OSP/C and OSP/I, respectively).</p>
+                            <h3 class="govuk-heading-s">Definitions</h3>
+                            <p>In this case, ‘an individual’ means someone with Garry’s characteristics and circumstances.</p>
+                            <h3 class="govuk-heading-s">How to use it</h3>
+                            <p>RSR scores should be used to underpin structured professional judgements of Risk of Serious Harm (RoSH). The scores can also be used to support decisions to allocate individuals within the National Probation Service.</p>
+                            <h3 class="govuk-heading-s">Things to note</h3>
+                            <p>Proven serious reoffending is rare. Fewer than 2% of the caseload commit a proven serious reoffence within 2 years of a release from prison or the start of a community order.</p>
+                            <p>There are two versions of RSR, depending how SNSV is scored: “brief static”, which uses similar risk factors to OGRS, and “extended static / dynamic” which incorporates dynamic risk factor and additional serious offending history data from the Offender Assessment System (OASys).</p>
+                            <h3 class="govuk-heading-s">How it is calculated</h3>
+                            <p>RSR is calculated from answers to static questions. Depending on the static data, there is the possibility of answering additional dynamic questions during the assessment.</p>
                         </div>
                     </details>
                 </div>
@@ -60,7 +76,17 @@
                             </span>
                         </summary>
                         <div class="govuk-details__text">
-                            PLACEHOLDER
+                            <h3 class="govuk-heading-s">What it shows</h3>
+                            <p>OSP/C is one of two scores that make up OSP. The other score is OSP/I.</p>
+                            <p>OSP/C predicts proven reoffending for a sexual or sexually motivated offence involving actual or attempted physical contact with a victim.</p>
+                            <h3 class="govuk-heading-s">Definitions</h3>
+                            <p>A contact offence is defined by intended, attempted or actual contact with a live human being. Offences such as inciting a child to engage in sexual activity and grooming can be considered a ‘contact’ offence, even if no physical contact has happened; for example, the contact has taken place over the internet.</p>
+                            <h3 class="govuk-heading-s">How to use it</h3>
+                            <p>OSP/C gives an outcome of ‘Low’, ‘Medium’, ‘High’ or ‘Very High’. Scores on an underlying 64-point scale are reported in these four groups.</p>
+                            <h3 class="govuk-heading-s">Things to note</h3>
+                            <p>OSP is only calculated for men with a known history of sexual offending, including sexually motivated offending. While OSP does not predict the likelihood of someone committing an “other noncontact” sexual reoffence such as voyeurism or indecent exposure, OSP must still be calculated for men with such offending histories, to estimate their contact sexual and indecent images reoffending risks.</p>
+                            <h3 class="govuk-heading-s">How it is calculated</h3>
+                            <p>OSP/C takes into account information about the individual such as age, number of sexual or sexually motivated offences, previous offending and if they have committed a contact or attempted contact offence against a stranger victim.</p>
                         </div>
                     </details>
                     <details class="govuk-details" data-module="govuk-details">
@@ -70,7 +96,16 @@
                             </span>
                         </summary>
                         <div class="govuk-details__text">
-                            PLACEHOLDER
+                            <h3 class="govuk-heading-s">What it shows</h3>
+                            <p>OSP/I is one of two scores that make up OSP. The other score is OSP/C.</p>
+                            <h3 class="govuk-heading-s">Definitions</h3>
+                            <p>OSP/I predicts proven reoffending involving possessing or downloading indecent images of children.</p>
+                            <h3 class="govuk-heading-s">How to use it</h3>
+                            <p>OSP/I is a 3 point scale, giving an outcome of ‘Low’, ‘Medium’ or ‘High’.</p>
+                            <h3 class="govuk-heading-s">Things to note</h3>
+                            <p>OSP is only calculated for men with a known history of sexual offending, including sexually motivated offending. While OSP does not predict the likelihood of someone committing an “other noncontact” sexual reoffence such as voyeurism or indecent exposure, OSP must still be calculated for men with such offending histories, to estimate their contact sexual and indecent images reoffending risks.</p>
+                            <h3 class="govuk-heading-s">How it is calculated</h3>
+                            <p>The OSP/I scale takes into account the overall number of current and previous convictions for IIOC offences.</p>
                         </div>
                     </details>
                 </div>

--- a/app/predictorScores/index.njk
+++ b/app/predictorScores/index.njk
@@ -1,5 +1,6 @@
 {% extends "common/templates/layout.njk" %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "common/templates/components/predictor-score/macro.njk" import predictorScore%}
 
 {% block pageTitle %}
     {{ heading }}
@@ -15,7 +16,9 @@
 {% endblock %}
 
 {% block content %}
-    <span class="govuk-caption-xl">{{ assessmentType }}</span>
+    {% if subheading %}
+    <span class="govuk-caption-xl">{{ subheading }}</span>
+    {% endif %}
     <h1 class="govuk-heading-xl">
         {{ heading }}
     </h1>
@@ -25,6 +28,7 @@
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <h2 class="govuk-heading-l">RSR score</h2>
+                    {{ predictorScore(predictorScores.current.scores.RSR) }}
                     <details class="govuk-details" data-module="govuk-details">
                         <summary class="govuk-details__summary">
                             <span class="govuk-details__summary-text">
@@ -40,9 +44,11 @@
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-one-half">
                     <h2 class="govuk-heading-l">OSP/C score</h2>
+                    {{ predictorScore(predictorScores.current.scores.OSPC) }}
                 </div>
                 <div class="govuk-grid-column-one-half">
                     <h2 class="govuk-heading-l">OSP/I score</h2>
+                    {{ predictorScore(predictorScores.current.scores.OSPI) }}
                 </div>
             </div>
             <div class="govuk-grid-row">

--- a/app/predictorScores/index.njk
+++ b/app/predictorScores/index.njk
@@ -113,8 +113,10 @@
             </div>
         </div>
         <div class="govuk-grid-column-one-third">
-            <h2 class="govuk-heading-l">Scores history</h2>
-            <a href="#" class="govuk-link">Open all</a>
+            <div class="govuk-body predictor-timeline__heading">
+                <h2 class="govuk-heading-l">Scores history</h2>
+                <a id="predictor-timeline__toggle-all" href="#" class="govuk-link">Open all</a>
+            </div>
             {{ predictorTimeline(predictorScores.historical) }}
         </div>
     </div>

--- a/app/predictorScores/index.njk
+++ b/app/predictorScores/index.njk
@@ -1,6 +1,7 @@
 {% extends "common/templates/layout.njk" %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% from "common/templates/components/predictor-score/macro.njk" import predictorScore%}
+{% from "common/templates/components/predictor-score/macro.njk" import predictorScore %}
+{% from "common/templates/components/predictor-timeline/macro.njk" import predictorTimeline %}
 
 {% block pageTitle %}
     {{ heading }}
@@ -114,6 +115,7 @@
         <div class="govuk-grid-column-one-third">
             <h2 class="govuk-heading-l">Scores history</h2>
             <a href="#" class="govuk-link">Open all</a>
+            {{ predictorTimeline(predictorScores.historical) }}
         </div>
     </div>
 

--- a/app/predictorScores/index.njk
+++ b/app/predictorScores/index.njk
@@ -1,10 +1,79 @@
 {% extends "common/templates/layout.njk" %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
-{% block pageTitle %}    
+{% block pageTitle %}
+    {{ heading }}
 {% endblock %}
 
 {% block beforeContent %}
+    <div role="navigation" aria-label="back">
+        {{ govukBackLink({
+            href: navigation.previous.url,
+            text: "Back to " + navigation.previous.name
+        }) }}
+    </div>
 {% endblock %}
 
 {% block content %}
+    <span class="govuk-caption-xl">{{ assessmentType }}</span>
+    <h1 class="govuk-heading-xl">
+        {{ heading }}
+    </h1>
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <h2 class="govuk-heading-l">RSR score</h2>
+                    <details class="govuk-details" data-module="govuk-details">
+                        <summary class="govuk-details__summary">
+                            <span class="govuk-details__summary-text">
+                                About RSR scores
+                            </span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            PLACEHOLDER
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-one-half">
+                    <h2 class="govuk-heading-l">OSP/C score</h2>
+                </div>
+                <div class="govuk-grid-column-one-half">
+                    <h2 class="govuk-heading-l">OSP/I score</h2>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <details class="govuk-details" data-module="govuk-details">
+                        <summary class="govuk-details__summary">
+                            <span class="govuk-details__summary-text">
+                                About OSP/C scores
+                            </span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            PLACEHOLDER
+                        </div>
+                    </details>
+                    <details class="govuk-details" data-module="govuk-details">
+                        <summary class="govuk-details__summary">
+                            <span class="govuk-details__summary-text">
+                                About OSP/I scores
+                            </span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            PLACEHOLDER
+                        </div>
+                    </details>
+                </div>
+            </div>
+        </div>
+        <div class="govuk-grid-column-one-third">
+            <h2 class="govuk-heading-l">Scores history</h2>
+            <a href="#" class="govuk-link">Open all</a>
+        </div>
+    </div>
+
 {% endblock %}

--- a/app/predictorScores/index.njk
+++ b/app/predictorScores/index.njk
@@ -1,4 +1,5 @@
 {% extends "common/templates/layout.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "common/templates/components/predictor-score/macro.njk" import predictorScore %}
 {% from "common/templates/components/predictor-timeline/macro.njk" import predictorTimeline %}
@@ -109,6 +110,22 @@
                             <p>The OSP/I scale takes into account the overall number of current and previous convictions for IIOC offences.</p>
                         </div>
                     </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <div class="govuk-button-group">
+                        {{ govukButton({
+                            text: "Submit scores to OASys",
+                            href: navigation.complete.url
+                        }) }}
+
+                        {{ govukButton({
+                            text: "Return to questions",
+                            classes: "govuk-button--secondary",
+                            href: navigation.previous.url
+                        }) }}
+                    </div>
                 </div>
             </div>
         </div>

--- a/app/predictorScores/index.njk
+++ b/app/predictorScores/index.njk
@@ -1,0 +1,10 @@
+{% extends "common/templates/layout.njk" %}
+
+{% block pageTitle %}    
+{% endblock %}
+
+{% block beforeContent %}
+{% endblock %}
+
+{% block content %}
+{% endblock %}

--- a/app/questionGroup/post.controller.js
+++ b/app/questionGroup/post.controller.js
@@ -19,7 +19,7 @@ const redirectsToScores = groupUuid => groupsThatRedirectToScores.includes(group
 
 const saveQuestionGroup = async (req, res) => {
   const {
-    params: { assessmentId, subIndex },
+    params: { assessmentId, groupId },
     user,
     errors,
     body: answers,
@@ -45,7 +45,7 @@ const saveQuestionGroup = async (req, res) => {
           },
         }
         req.session.save()
-        return res.redirect(`/episode/${episodeUuid}/scores`)
+        return res.redirect(`/episode/${episodeUuid}/${groupId}/scores`)
       }
 
       return res.redirect(`/${assessmentId}/questiongroup/${res.locals.navigation.next.url}`)

--- a/app/questionGroup/post.controller.js
+++ b/app/questionGroup/post.controller.js
@@ -3,6 +3,7 @@ const { logger } = require('../../common/logging/logger')
 const { displayQuestionGroup } = require('./get.controller')
 const { postAnswers } = require('../../common/data/hmppsAssessmentApi')
 const { formatValidationErrors } = require('../../common/middleware/questionGroups/postHandlers')
+const { cachePredictorScoresForEpisode } = require('../../common/data/predictorScores')
 
 const getErrorMessage = reason => {
   if (reason === 'OASYS_PERMISSION') {
@@ -27,10 +28,10 @@ const saveQuestionGroup = async (req, res) => {
     const [ok, response] = await postAnswers(assessmentId, 'current', { answers }, user?.token, user?.id)
 
     if (ok) {
-      const { episodeUuid, predictors = [] } = response
-      logger.info(`Received ${predictors.length} predictor scores for episode: ${episodeUuid}`)
+      const { episodeUuid, predictors: predictorScores = [] } = response
+      logger.info(`Received ${predictorScores.length} predictor scores for episode: ${episodeUuid}`)
 
-      // cache ready for redirect
+      await cachePredictorScoresForEpisode(episodeUuid, predictorScores)
 
       return res.redirect(`/${assessmentId}/questiongroup/${res.locals.navigation.next.url}`)
     }

--- a/app/router.js
+++ b/app/router.js
@@ -55,6 +55,7 @@ const { checkUserHasAreaSelected } = require('../common/middleware/area-selectio
 const {
   dev: { devAssessmentId },
 } = require('../common/config')
+const { displayPredictorScores } = require('./predictorScores/get.controller')
 
 const assessmentUrl = `/${devAssessmentId}/questiongroup/ROSH/summary`
 
@@ -188,6 +189,8 @@ module.exports = app => {
   app.get('/assessment-from-delius', assessmentFromCrn)
   app.post('/assessment-from-delius', startAssessmentFromForm)
   app.post('/assessment-from-delius/:assessmentSchemaCode/crn/:crn/event/:deliusEventId', startAssessmentFromCrn)
+
+  app.get('/episode/:episodeUuid/scores', displayPredictorScores)
 
   app.use((error, req, res, next) =>
     res.render('app/error', {

--- a/app/router.js
+++ b/app/router.js
@@ -56,6 +56,7 @@ const {
   dev: { devAssessmentId },
 } = require('../common/config')
 const { displayPredictorScores } = require('./predictorScores/get.controller')
+const { submitPredictorScores } = require('./submitPredictorScores/get.controller')
 
 const assessmentUrl = `/${devAssessmentId}/questiongroup/ROSH/summary`
 
@@ -191,6 +192,7 @@ module.exports = app => {
   app.post('/assessment-from-delius/:assessmentSchemaCode/crn/:crn/event/:deliusEventId', startAssessmentFromCrn)
 
   app.get('/episode/:episodeUuid/:assessmentType/scores', displayPredictorScores)
+  app.get('/episode/:episodeUuid/:assessmentType/scores/complete', submitPredictorScores)
 
   app.use((error, req, res, next) =>
     res.render('app/error', {

--- a/app/router.js
+++ b/app/router.js
@@ -190,7 +190,7 @@ module.exports = app => {
   app.post('/assessment-from-delius', startAssessmentFromForm)
   app.post('/assessment-from-delius/:assessmentSchemaCode/crn/:crn/event/:deliusEventId', startAssessmentFromCrn)
 
-  app.get('/episode/:episodeUuid/scores', displayPredictorScores)
+  app.get('/episode/:episodeUuid/:assessmentType/scores', displayPredictorScores)
 
   app.use((error, req, res, next) =>
     res.render('app/error', {

--- a/app/submitPredictorScores/get.controller.js
+++ b/app/submitPredictorScores/get.controller.js
@@ -1,0 +1,26 @@
+const { logger } = require('../../common/logging/logger')
+
+const submitPredictorScores = async (req, res) => {
+  try {
+    const {
+      params: { episodeUuid, assessmentType },
+    } = req
+
+    const offenderName = res.locals.offenderDetails?.name || 'the offender'
+
+    logger.info(`Creating final predictor scores for episode: ${episodeUuid} of type: ${assessmentType}`)
+
+    // TODO: Call assessments API to finalise the predictor scores
+
+    return res.render(`${__dirname}/index`, {
+      panelText: `Your answers and scores for ${offenderName} have been uploaded to OASys`,
+      navigation: {
+        next: { url: '/' },
+      },
+    })
+  } catch (error) {
+    return res.render('app/error', { error })
+  }
+}
+
+module.exports = { submitPredictorScores }

--- a/app/submitPredictorScores/get.controller.test.js
+++ b/app/submitPredictorScores/get.controller.test.js
@@ -1,0 +1,32 @@
+const { submitPredictorScores } = require('./get.controller')
+
+describe('display predictor scores', () => {
+  const req = {
+    params: {
+      episodeUuid: '22222222-2222-2222-2222-222222222222',
+      assessmentType: 'RSR',
+    },
+  }
+  const res = {
+    render: jest.fn(),
+    redirect: jest.fn(),
+    locals: {
+      offenderDetails: {
+        name: 'Bob Ross',
+      },
+    },
+  }
+
+  it('displays a message on submission', async () => {
+    await submitPredictorScores(req, res)
+
+    expect(res.render).toHaveBeenCalledWith(`${__dirname}/index`, {
+      panelText: 'Your answers and scores for Bob Ross have been uploaded to OASys',
+      navigation: {
+        next: {
+          url: '/',
+        },
+      },
+    })
+  })
+})

--- a/app/submitPredictorScores/index.njk
+++ b/app/submitPredictorScores/index.njk
@@ -1,0 +1,25 @@
+{% extends "common/templates/layout.njk" %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block pageTitle %}
+    {{ heading }}
+{% endblock %}
+
+{% block beforeContent %}
+{% endblock %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            {{ govukPanel({
+                titleText: panelText,
+                classes: "predictor-complete-panel"
+            }) }}
+            {{ govukButton({
+                text: "Close the RSR calculator",
+                href: navigation.next.url
+            }) }}
+        </div>
+    </div>
+{% endblock %}

--- a/common/assets/javascripts/predictors.js
+++ b/common/assets/javascripts/predictors.js
@@ -1,0 +1,67 @@
+/* eslint-disable */
+var allHidden = true
+var openText = 'Open'
+var closeText = 'Close'
+
+function attachListenerForToggleSectionButton(button, section, initiallyHidden) {
+  button.setAttribute('data-section-is-hidden', initiallyHidden)
+
+  button.onclick = function(e) {
+    e.preventDefault()
+
+    var sectionIsHidden = button.dataset.sectionIsHidden === 'true'
+
+    if (sectionIsHidden) {
+      button.innerText = closeText
+      section.classList.remove('predictor-timeline-section--hidden')
+    } else {
+      button.innerText = openText
+      section.classList.add('predictor-timeline-section--hidden')
+    }
+
+    button.setAttribute('data-section-is-hidden', !sectionIsHidden)
+  }
+}
+
+function attachListenerForToggleAllButton(button, sections) {
+  button.setAttribute('data-sections-are-hidden', allHidden)
+
+  button.onclick = function(e) {
+    e.preventDefault()
+
+    for (var i = 0; i < sections.length; i++) {
+      sections[i].classList.remove('predictor-timeline-section--hidden')
+
+      var openSectionButtons = sections[i].getElementsByClassName('predictor-timeline__toggle-section')
+
+      for (var j = 0; j < openSectionButtons.length; j++) {
+        openSectionButtons[j].setAttribute('data-section-is-hidden', false)
+        openSectionButtons[j].innerText = closeText
+      }
+    }
+  }
+}
+
+function addPredictorTimelineListeners() {
+  var openAllButton = document.getElementById('predictor-timeline__toggle-all')
+  var sections = document.getElementsByClassName('predictor-timeline-section')
+
+  for (var i = 0; i < sections.length; i++) {
+    if (allHidden) {
+      sections[i].classList.add('predictor-timeline-section--hidden')
+    }
+
+    var openSectionButtons = sections[i].getElementsByClassName('predictor-timeline__toggle-section')
+    for (var j = 0; j < openSectionButtons.length; j++) {
+      attachListenerForToggleSectionButton(openSectionButtons[j], sections[i], allHidden)
+    }
+  }
+
+  if (openAllButton) {
+    attachListenerForToggleAllButton(openAllButton, sections)
+  }
+}
+
+;(function() {
+  addPredictorTimelineListeners()
+})()

--- a/common/assets/javascripts/predictors.js
+++ b/common/assets/javascripts/predictors.js
@@ -51,7 +51,7 @@ function addPredictorTimelineListeners() {
       sections[i].classList.add('predictor-timeline-section--hidden')
     }
 
-    var openSectionButtons = sections[i].getElementsByClassName('predictor-timeline__toggle-section')
+    var openSectionButtons = sections[i].parentElement.getElementsByClassName('predictor-timeline__toggle-section')
     for (var j = 0; j < openSectionButtons.length; j++) {
       attachListenerForToggleSectionButton(openSectionButtons[j], sections[i], allHidden)
     }

--- a/common/assets/sass/application.scss
+++ b/common/assets/sass/application.scss
@@ -4,6 +4,7 @@
 @import 'components/accessible-autocomplete';
 @import 'components/cookie-message';
 @import 'components/task-list';
+@import 'components/predictor-scores';
 @import 'pages';
 
 $white-transparent: rgba(255, 255, 255, 0.25);

--- a/common/assets/sass/components/_predictor-scores.scss
+++ b/common/assets/sass/components/_predictor-scores.scss
@@ -1,4 +1,4 @@
-@use "sass:math";
+@use 'sass:math';
 
 $very-high-score-colour: #761708;
 $very-high-score-colour--light: #a33322;

--- a/common/assets/sass/components/_predictor-scores.scss
+++ b/common/assets/sass/components/_predictor-scores.scss
@@ -355,3 +355,17 @@ $predictor-score-background-colour: #f3f2f1;
 .predictor-timeline-item--low {
   @include predictor-timeline-item-base($low-score-colour, $low-score-colour--light);
 }
+
+.predictor-timeline-section--hidden {
+  & div {
+    visibility: none;
+    display: none;
+  }
+}
+
+.predictor-timeline__heading {
+  h2,
+  a {
+    display: inline;
+  }
+}

--- a/common/assets/sass/components/_predictor-scores.scss
+++ b/common/assets/sass/components/_predictor-scores.scss
@@ -1,0 +1,309 @@
+@use "sass:math";
+
+$very-high-score-colour: #761708;
+$very-high-score-colour--light: #a33322;
+$high-score-colour: #d4351c;
+$high-score-colour--light: #e97766;
+$medium-score-colour: #f47738;
+$medium-score-colour--light: #fc9c6b;
+$low-score-colour: #85994b;
+$low-score-colour--light: #dee9bd;
+$predictor-score-background-colour: #f3f2f1;
+
+@mixin score-label-card-colour($primary-colour, $secondary-colour) {
+  & .score-label__card {
+    border: 2px solid $primary-colour;
+
+    & .score-label__card-top {
+      & h3,
+      & p {
+        color: $primary-colour;
+      }
+    }
+
+    & .score-label__card-bottom {
+      background-color: $secondary-colour;
+    }
+
+    & .score-label__card-pointer {
+      border-top: 16px solid $primary-colour;
+    }
+
+    & .score-label__card-pointer::after {
+      border-top: 14px solid $secondary-colour;
+    }
+  }
+}
+
+@mixin score-bar-label {
+  position: relative;
+  text-align: center;
+  display: block;
+  color: govuk-colour('black');
+}
+
+@mixin score-bar-base {
+  width: 100%;
+
+  &::after {
+    content: ' ';
+    display: block;
+    visibility: hidden;
+    clear: both;
+  }
+
+  & div > span {
+    height: 15px;
+    display: block;
+  }
+}
+
+.predictor-score {
+  width: 100%;
+  padding: 30px 40px 10px 40px;
+  box-sizing: border-box;
+  background-color: $predictor-score-background-colour;
+}
+
+.score-label__card-pointer {
+  width: 0;
+  height: 0;
+  border-right: 16px solid transparent;
+  border-left: 16px solid transparent;
+  border-top: 16px solid govuk-colour('black');
+  position: relative;
+  top: 0;
+  left: 23px;
+  float: left;
+}
+
+.score-label__card-pointer--white::after {
+  border-top: 14px solid govuk-colour('white') !important;
+}
+
+.score-label__card-pointer::after {
+  width: 0;
+  height: 0;
+  border-right: 14px solid transparent;
+  border-left: 14px solid transparent;
+  border-top: 14px solid govuk-colour('white');
+  position: absolute;
+  top: -17px;
+  left: -14px;
+  content: '';
+}
+
+.score-label {
+  margin-bottom: 22px;
+  width: 100%;
+}
+
+.score-label-wrapper--position-one-of-three,
+.score-label-wrapper--position-two-of-three,
+.score-label-wrapper--position-three-of-three {
+  width: percentage(math.div(1, 3));
+}
+
+.score-label-wrapper--position-one-of-three {
+  margin-left: 0;
+}
+
+.score-label-wrapper--position-two-of-three {
+  margin-left: percentage(math.div(1, 3));
+}
+
+.score-label-wrapper--position-three-of-three {
+  margin-left: percentage(math.div(2, 3));
+}
+
+.score-label-wrapper--position-one-of-four,
+.score-label-wrapper--position-two-of-four,
+.score-label-wrapper--position-three-of-four,
+.score-label-wrapper--position-four-of-four {
+  width: percentage(math.div(1, 4));
+}
+
+.score-label-wrapper--position-one-of-four {
+  margin-left: 0;
+}
+
+.score-label-wrapper--position-two-of-four {
+  margin-left: percentage(math.div(1, 4));
+}
+
+.score-label-wrapper--position-three-of-four {
+  margin-left: percentage(math.div(2, 4));
+}
+
+.score-label-wrapper--position-four-of-four {
+  margin-left: percentage(math.div(3, 4));
+}
+
+.score-label-wrapper--very-high {
+  @include score-label-card-colour($very-high-score-colour, $very-high-score-colour--light);
+}
+
+.score-label-wrapper--high {
+  @include score-label-card-colour($high-score-colour, $high-score-colour--light);
+}
+
+.score-label-wrapper--medium {
+  @include score-label-card-colour($medium-score-colour, $medium-score-colour--light);
+}
+
+.score-label-wrapper--low {
+  @include score-label-card-colour($low-score-colour, $low-score-colour--light);
+}
+
+.score-label__card {
+  width: 78px;
+  bottom: 30px;
+  margin: 0 auto 0;
+  background-color: govuk-colour('white');
+  border: 2px solid govuk-colour('black');
+}
+
+.score-label__card-top {
+  width: 100%;
+
+  & h3,
+  & p {
+    margin: 0;
+    text-align: center;
+    text-transform: uppercase;
+  }
+
+  & h3 {
+    @include govuk-font(14, 'bold');
+  }
+
+  & p {
+    @include govuk-font(14, 'regular');
+  }
+}
+
+.score-label__card-bottom p {
+  @include govuk-font(14, 'bold');
+
+  margin: 0;
+}
+
+.score-label__card-top,
+.score-label__card-bottom {
+  padding: 3px;
+  text-align: center;
+  box-sizing: border-box;
+}
+
+.score-bar--small {
+  @include score-bar-base;
+
+  margin-bottom: 15px;
+
+  & > div {
+    width: percentage(math.div(1, 3));
+    display: inline;
+    float: left;
+    border-right: 1px solid transparent;
+    box-sizing: border-box;
+  }
+
+  & div:nth-child(4n + 1) > span:first-child {
+    background-color: $low-score-colour;
+  }
+
+  & div:nth-child(4n + 2) > span:first-child {
+    background-color: $medium-score-colour;
+  }
+
+  & div:nth-child(4n + 3) > span:first-child {
+    background-color: $high-score-colour;
+  }
+}
+
+.score-bar--small-fourths {
+  & > div {
+    width: percentage(math.div(1, 4));
+  }
+
+  & div:nth-child(4n + 4) > span:first-child {
+    background-color: $very-high-score-colour;
+  }
+}
+
+.score-bar {
+  @include score-bar-base;
+
+  margin-bottom: 35px;
+
+  & > div {
+    width: percentage(math.div(1, 3));
+    height: 30px;
+    display: inline;
+    float: left;
+    border-right: 1px solid govuk-colour('black');
+    box-sizing: border-box;
+  }
+
+  & > div:first-child {
+    border-left: 1px solid govuk-colour('black');
+  }
+
+  & div:nth-child(4n + 1) {
+    &::before {
+      @include govuk-font(16, 'bold');
+      @include score-bar-label;
+
+      float: left;
+      content: '0%';
+      left: -5%;
+      bottom: -35px;
+    }
+
+    &::after {
+      @include govuk-font(16, 'bold');
+      @include score-bar-label;
+
+      float: right;
+      content: '3%';
+      right: -5%;
+      bottom: -20px;
+    }
+
+    & > span:first-child {
+      background-color: $low-score-colour;
+    }
+  }
+
+  & div:nth-child(4n + 2) {
+    &::after {
+      @include govuk-font(16, 'bold');
+      @include score-bar-label;
+
+      content: '6.9%';
+      float: right;
+      right: -11%;
+      bottom: -20px;
+    }
+
+    & > span:first-child {
+      background-color: $medium-score-colour;
+    }
+  }
+
+  & div:nth-child(4n + 3) {
+    &::after {
+      @include govuk-font(16, 'bold');
+      @include score-bar-label;
+
+      float: right;
+      content: '25%+';
+      right: -12%;
+      bottom: -20px;
+    }
+
+    & > span:first-child {
+      background-color: $high-score-colour;
+    }
+  }
+}

--- a/common/assets/sass/components/_predictor-scores.scss
+++ b/common/assets/sass/components/_predictor-scores.scss
@@ -58,6 +58,68 @@ $predictor-score-background-colour: #f3f2f1;
   }
 }
 
+@mixin predictor-timeline-item-base($primary-colour, $secondary-colour) {
+  outline: 2px solid $primary-colour;
+  padding: 0;
+  display: inline-block;
+
+  &::after {
+    content: ' ';
+    display: block;
+    visibility: hidden;
+    clear: both;
+  }
+
+  & > span {
+    padding: 3px 6px;
+  }
+
+  & .predictor-timeline-item__level {
+    @include govuk-font(14, 'regular');
+
+    float: left;
+    color: $primary-colour;
+  }
+
+  & .predictor-timeline-item__score {
+    @include govuk-font(14, 'bold');
+
+    float: right;
+    color: govuk-colour('black');
+    background-color: $secondary-colour;
+  }
+}
+
+.predictor-timeline-item--very-high {
+  @include predictor-timeline-item-base($very-high-score-colour, $very-high-score-colour--light);
+}
+
+.predictor-timeline-item--high {
+  @include predictor-timeline-item-base($high-score-colour, $high-score-colour--light);
+}
+
+.predictor-timeline-item--medium {
+  @include predictor-timeline-item-base($medium-score-colour, $medium-score-colour--light);
+}
+
+.predictor-timeline-item--low {
+  @include predictor-timeline-item-base($low-score-colour, $low-score-colour--light);
+}
+
+.predictor-timeline-section--hidden {
+  & > div {
+    visibility: none;
+    display: none;
+  }
+}
+
+.predictor-timeline__heading {
+  h2,
+  a {
+    display: inline;
+  }
+}
+
 .predictor-score {
   width: 100%;
   padding: 30px 40px 10px 40px;
@@ -305,67 +367,5 @@ $predictor-score-background-colour: #f3f2f1;
     & > span:first-child {
       background-color: $high-score-colour;
     }
-  }
-}
-
-@mixin predictor-timeline-item-base($primary-colour, $secondary-colour) {
-  outline: 2px solid $primary-colour;
-  padding: 0;
-  display: inline-block;
-
-  &::after {
-    content: ' ';
-    display: block;
-    visibility: hidden;
-    clear: both;
-  }
-
-  & > span {
-    padding: 3px 6px;
-  }
-
-  & .predictor-timeline-item__level {
-    @include govuk-font(14, 'regular');
-
-    float: left;
-    color: $primary-colour;
-  }
-
-  & .predictor-timeline-item__score {
-    @include govuk-font(14, 'bold');
-
-    float: right;
-    color: govuk-colour('black');
-    background-color: $secondary-colour;
-  }
-}
-
-.predictor-timeline-item--very-high {
-  @include predictor-timeline-item-base($very-high-score-colour, $very-high-score-colour--light);
-}
-
-.predictor-timeline-item--high {
-  @include predictor-timeline-item-base($high-score-colour, $high-score-colour--light);
-}
-
-.predictor-timeline-item--medium {
-  @include predictor-timeline-item-base($medium-score-colour, $medium-score-colour--light);
-}
-
-.predictor-timeline-item--low {
-  @include predictor-timeline-item-base($low-score-colour, $low-score-colour--light);
-}
-
-.predictor-timeline-section--hidden {
-  & > div {
-    visibility: none;
-    display: none;
-  }
-}
-
-.predictor-timeline__heading {
-  h2,
-  a {
-    display: inline;
   }
 }

--- a/common/assets/sass/components/_predictor-scores.scss
+++ b/common/assets/sass/components/_predictor-scores.scss
@@ -1,13 +1,13 @@
 @use 'sass:math';
 
 $very-high-score-colour: #761708;
-$very-high-score-colour--light: #a33322;
+$very-high-score-colour--light: desaturate(lighten($very-high-score-colour, 40%), 20%);
 $high-score-colour: #d4351c;
-$high-score-colour--light: #e97766;
-$medium-score-colour: #f47738;
-$medium-score-colour--light: #fc9c6b;
-$low-score-colour: #85994b;
-$low-score-colour--light: #dee9bd;
+$high-score-colour--light: desaturate(lighten($high-score-colour, 40%), 20%);
+$medium-score-colour: #bb5c00;
+$medium-score-colour--light: desaturate(lighten($medium-score-colour, 40%), 20%);
+$low-score-colour: #00703c;
+$low-score-colour--light: desaturate(lighten($low-score-colour, 40%), 20%);
 $predictor-score-background-colour: #f3f2f1;
 
 @mixin score-label-card-colour($primary-colour, $secondary-colour) {
@@ -107,7 +107,7 @@ $predictor-score-background-colour: #f3f2f1;
 }
 
 .predictor-timeline-section--hidden {
-  & > div {
+  & {
     visibility: none;
     display: none;
   }

--- a/common/assets/sass/components/_predictor-scores.scss
+++ b/common/assets/sass/components/_predictor-scores.scss
@@ -52,7 +52,7 @@ $predictor-score-background-colour: #f3f2f1;
     clear: both;
   }
 
-  & div > span {
+  & > div > span {
     height: 15px;
     display: block;
   }
@@ -208,15 +208,15 @@ $predictor-score-background-colour: #f3f2f1;
     box-sizing: border-box;
   }
 
-  & div:nth-child(4n + 1) > span:first-child {
+  & > div:nth-child(4n + 1) > span:first-child {
     background-color: $low-score-colour;
   }
 
-  & div:nth-child(4n + 2) > span:first-child {
+  & > div:nth-child(4n + 2) > span:first-child {
     background-color: $medium-score-colour;
   }
 
-  & div:nth-child(4n + 3) > span:first-child {
+  & > div:nth-child(4n + 3) > span:first-child {
     background-color: $high-score-colour;
   }
 }
@@ -226,7 +226,7 @@ $predictor-score-background-colour: #f3f2f1;
     width: percentage(math.div(1, 4));
   }
 
-  & div:nth-child(4n + 4) > span:first-child {
+  & > div:nth-child(4n + 4) > span:first-child {
     background-color: $very-high-score-colour;
   }
 }
@@ -249,7 +249,7 @@ $predictor-score-background-colour: #f3f2f1;
     border-left: 1px solid govuk-colour('black');
   }
 
-  & div:nth-child(4n + 1) {
+  & > div:nth-child(4n + 1) {
     &::before {
       @include govuk-font(16, 'bold');
       @include score-bar-label;
@@ -275,7 +275,7 @@ $predictor-score-background-colour: #f3f2f1;
     }
   }
 
-  & div:nth-child(4n + 2) {
+  & > div:nth-child(4n + 2) {
     &::after {
       @include govuk-font(16, 'bold');
       @include score-bar-label;
@@ -291,7 +291,7 @@ $predictor-score-background-colour: #f3f2f1;
     }
   }
 
-  & div:nth-child(4n + 3) {
+  & > div:nth-child(4n + 3) {
     &::after {
       @include govuk-font(16, 'bold');
       @include score-bar-label;
@@ -320,7 +320,7 @@ $predictor-score-background-colour: #f3f2f1;
     clear: both;
   }
 
-  & span {
+  & > span {
     padding: 3px 6px;
   }
 
@@ -357,7 +357,7 @@ $predictor-score-background-colour: #f3f2f1;
 }
 
 .predictor-timeline-section--hidden {
-  & div {
+  & > div {
     visibility: none;
     display: none;
   }

--- a/common/assets/sass/components/_predictor-scores.scss
+++ b/common/assets/sass/components/_predictor-scores.scss
@@ -107,10 +107,8 @@ $predictor-score-background-colour: #f3f2f1;
 }
 
 .predictor-timeline-section--hidden {
-  & {
-    visibility: none;
-    display: none;
-  }
+  visibility: none;
+  display: none;
 }
 
 .predictor-timeline__heading {

--- a/common/assets/sass/components/_predictor-scores.scss
+++ b/common/assets/sass/components/_predictor-scores.scss
@@ -307,3 +307,51 @@ $predictor-score-background-colour: #f3f2f1;
     }
   }
 }
+
+@mixin predictor-timeline-item-base($primary-colour, $secondary-colour) {
+  outline: 2px solid $primary-colour;
+  padding: 0;
+  display: inline-block;
+
+  &::after {
+    content: ' ';
+    display: block;
+    visibility: hidden;
+    clear: both;
+  }
+
+  & span {
+    padding: 3px 6px;
+  }
+
+  & .predictor-timeline-item__level {
+    @include govuk-font(14, 'regular');
+
+    float: left;
+    color: $primary-colour;
+  }
+
+  & .predictor-timeline-item__score {
+    @include govuk-font(14, 'bold');
+
+    float: right;
+    color: govuk-colour('black');
+    background-color: $secondary-colour;
+  }
+}
+
+.predictor-timeline-item--very-high {
+  @include predictor-timeline-item-base($very-high-score-colour, $very-high-score-colour--light);
+}
+
+.predictor-timeline-item--high {
+  @include predictor-timeline-item-base($high-score-colour, $high-score-colour--light);
+}
+
+.predictor-timeline-item--medium {
+  @include predictor-timeline-item-base($medium-score-colour, $medium-score-colour--light);
+}
+
+.predictor-timeline-item--low {
+  @include predictor-timeline-item-base($low-score-colour, $low-score-colour--light);
+}

--- a/common/assets/sass/components/_predictor-scores.scss
+++ b/common/assets/sass/components/_predictor-scores.scss
@@ -369,3 +369,7 @@ $predictor-score-background-colour: #f3f2f1;
     }
   }
 }
+
+.predictor-complete-panel {
+  margin-bottom: 50px;
+}

--- a/common/data/predictorScores.js
+++ b/common/data/predictorScores.js
@@ -1,0 +1,15 @@
+const redis = require('./redis')
+const { ONE_DAY } = require('../utils/constants')
+
+const cachePredictorScoresForEpisode = async (episodeUuid, predictorScores) => {
+  await redis.set(`predictors:${episodeUuid}`, JSON.stringify(predictorScores), 'EX', ONE_DAY)
+}
+const getPredictorScoresForEpisode = async episodeUuid => {
+  const serializedScores = await redis.get(`predictors:${episodeUuid}`)
+  return serializedScores !== null ? JSON.parse(serializedScores) : null
+}
+
+module.exports = {
+  cachePredictorScoresForEpisode,
+  getPredictorScoresForEpisode,
+}

--- a/common/templates/components/predictor-indicator/macro.njk
+++ b/common/templates/components/predictor-indicator/macro.njk
@@ -1,0 +1,3 @@
+{% macro predictorIndicator(predictorScore) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/common/templates/components/predictor-indicator/template.njk
+++ b/common/templates/components/predictor-indicator/template.njk
@@ -1,0 +1,14 @@
+<div class="score-label__card">
+    <div class="score-label__card-top">
+        <h3>{{ predictorScore.level }}</h3>
+        <p>{{ predictorScore.type }}</p>
+    </div>
+    {% if predictorScore.type === 'RSR' %}
+    <div class="score-label__card-bottom">
+        <p>{{ predictorScore.score }}</p>
+    </div>
+    <div class="score-label__card-pointer"></div>
+    {% else %}
+    <div class="score-label__card-pointer score-label__card-pointer--white"></div>
+    {% endif %}
+</div>

--- a/common/templates/components/predictor-indicator/template.njk
+++ b/common/templates/components/predictor-indicator/template.njk
@@ -3,7 +3,7 @@
         <h3>{{ predictorScore.level }}</h3>
         <p>{{ predictorScore.type }}</p>
     </div>
-    {% if predictorScore.type === 'RSR' %}
+    {% if predictorScore.score %}
     <div class="score-label__card-bottom">
         <p>{{ predictorScore.score }}</p>
     </div>

--- a/common/templates/components/predictor-score/macro.njk
+++ b/common/templates/components/predictor-score/macro.njk
@@ -1,0 +1,3 @@
+{% macro predictorScore(predictorScore) %}
+  {%- include "./template.njk" -%}  
+{% endmacro %}

--- a/common/templates/components/predictor-score/template.njk
+++ b/common/templates/components/predictor-score/template.njk
@@ -1,5 +1,7 @@
 {% from "common/templates/components/predictor-indicator/macro.njk" import predictorIndicator %}
 
+{% set scoreLabelClass = '' %}
+
 {% if predictorScore.level === 'LOW' and (predictorScore.type  === 'RSR' or predictorScore.type  === 'OSP/I')%}
     {% set scoreLabelClass = 'score-label-wrapper--low score-label-wrapper--position-one-of-three' %}
 {% elif predictorScore.level === 'MEDIUM' and (predictorScore.type  === 'RSR' or predictorScore.type  === 'OSP/I') %}
@@ -14,7 +16,7 @@
     {% set scoreLabelClass = 'score-label-wrapper--high score-label-wrapper--position-three-of-four' %}
 {% elif predictorScore.level === 'VERY_HIGH' and predictorScore.type  === 'OSP/C' %}
     {% set scoreLabelClass = 'score-label-wrapper--very-high score-label-wrapper--position-four-of-four' %}
-{% endif%}
+{% endif %}
 
 {% set barTypeClass = '' %}
 
@@ -42,8 +44,8 @@
         </div>
         <div>
             <span></span>
-        </div>
-        {% if predictorScore.type === 'OSP/I' %}
+        </div>        
+        {% if predictorScore.type === 'OSP/C' %}
         <div>
             <span></span>
         </div>

--- a/common/templates/components/predictor-score/template.njk
+++ b/common/templates/components/predictor-score/template.njk
@@ -27,7 +27,7 @@
         {% set barTypeClass = 'score-bar--small'%}
     {% case 'OSP/C' %}
         {% set barTypeClass = 'score-bar--small score-bar--small-fourths' %}
-{% endswitch%}
+{% endswitch %}
 
 <div class="predictor-score govuk-body">
     <div class="score-label">

--- a/common/templates/components/predictor-score/template.njk
+++ b/common/templates/components/predictor-score/template.njk
@@ -1,0 +1,52 @@
+{% from "common/templates/components/predictor-indicator/macro.njk" import predictorIndicator %}
+
+{% if predictorScore.level === 'LOW' and (predictorScore.type  === 'RSR' or predictorScore.type  === 'OSP/I')%}
+    {% set scoreLabelClass = 'score-label-wrapper--low score-label-wrapper--position-one-of-three' %}
+{% elif predictorScore.level === 'MEDIUM' and (predictorScore.type  === 'RSR' or predictorScore.type  === 'OSP/I') %}
+    {% set scoreLabelClass = 'score-label-wrapper--medium score-label-wrapper--position-two-of-three' %}
+{% elif predictorScore.level === 'HIGH' and (predictorScore.type  === 'RSR' or predictorScore.type  === 'OSP/I') %}
+    {% set scoreLabelClass = 'score-label-wrapper--high score-label-wrapper--position-three-of-three' %}
+{% elif predictorScore.level === 'LOW' and predictorScore.type  === 'OSP/C' %}
+    {% set scoreLabelClass = 'score-label-wrapper--medium score-label-wrapper--position-one-of-four' %}
+{% elif predictorScore.level === 'MEDIUM' and predictorScore.type  === 'OSP/C' %}    
+    {% set scoreLabelClass = 'score-label-wrapper--medium score-label-wrapper--position-two-of-four' %}
+{% elif predictorScore.level === 'HIGH' and predictorScore.type  === 'OSP/C' %}
+    {% set scoreLabelClass = 'score-label-wrapper--high score-label-wrapper--position-three-of-four' %}
+{% elif predictorScore.level === 'VERY_HIGH' and predictorScore.type  === 'OSP/C' %}
+    {% set scoreLabelClass = 'score-label-wrapper--very-high score-label-wrapper--position-four-of-four' %}
+{% endif%}
+
+{% set barTypeClass = '' %}
+
+{% switch predictorScore.type %}
+    {% case 'RSR' %}
+        {% set barTypeClass = 'score-bar'%}
+    {% case 'OSP/I' %}
+        {% set barTypeClass = 'score-bar--small'%}
+    {% case 'OSP/C' %}
+        {% set barTypeClass = 'score-bar--small score-bar--small-fourths' %}
+{% endswitch%}
+
+<div class="predictor-score govuk-body">
+    <div class="score-label">
+        <div class="{{ scoreLabelClass }}">
+            {{ predictorIndicator(predictorScore) }}
+        </div>
+    </div>
+    <div class="{{ barTypeClass }}">
+        <div>
+            <span></span>
+        </div>
+        <div>
+            <span></span>
+        </div>
+        <div>
+            <span></span>
+        </div>
+        {% if predictorScore.type === 'OSP/I' %}
+        <div>
+            <span></span>
+        </div>
+        {% endif %}
+    </div>
+</div>

--- a/common/templates/components/predictor-timeline-item/macro.njk
+++ b/common/templates/components/predictor-timeline-item/macro.njk
@@ -1,0 +1,3 @@
+{% macro predictorTimelineItem(predictor) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/common/templates/components/predictor-timeline-item/template.njk
+++ b/common/templates/components/predictor-timeline-item/template.njk
@@ -1,0 +1,22 @@
+{% if predictor %}
+
+{% set timelineItemClass = '' %}
+
+{% switch predictor.level %}
+    {% case 'VERY_HIGH' %}
+        {% set timelineItemClass = 'predictor-timeline-item--very-high'%}
+    {% case 'HIGH' %}
+        {% set timelineItemClass = 'predictor-timeline-item--high'%}
+    {% case 'MEDIUM' %}
+        {% set timelineItemClass = 'predictor-timeline-item--medium' %}
+    {% case 'LOW' %}
+        {% set timelineItemClass = 'predictor-timeline-item--low' %}
+{% endswitch %}
+
+<div class="{{ timelineItemClass }}">
+    <span class="predictor-timeline-item__level"><strong>{{ predictor.type }}</strong> {{ predictor.level }}</span>
+    {% if predictor.score %}
+    <span class="predictor-timeline-item__score">{{ predictor.score }}</span>
+    {% endif %}
+</div>
+{% endif %}

--- a/common/templates/components/predictor-timeline/macro.njk
+++ b/common/templates/components/predictor-timeline/macro.njk
@@ -1,0 +1,3 @@
+{% macro predictorTimeline(predictorScores) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/common/templates/components/predictor-timeline/template.njk
+++ b/common/templates/components/predictor-timeline/template.njk
@@ -8,15 +8,13 @@
         </div>
         <div class="moj-timeline__description">
             <div class="predictor-timeline-section">
-                <div>
-                    <ul class="govuk-list">
-                        <li>{{ predictorTimelineItem(item.scores.RSR) }}</li>
-                        <li>{{ predictorTimelineItem(item.scores.OSPC) }}</li>
-                        <li>{{ predictorTimelineItem(item.scores.OSPI) }}</li>
-                    </ul>
-                </div>
-                <a href="#" class="govuk-link predictor-timeline__toggle-section">Open</a>
+                <ul class="govuk-list">
+                    <li>{{ predictorTimelineItem(item.scores.RSR) }}</li>
+                    <li>{{ predictorTimelineItem(item.scores.OSPC) }}</li>
+                    <li>{{ predictorTimelineItem(item.scores.OSPI) }}</li>
+                </ul>
             </div>
+            <a href="#" class="govuk-link predictor-timeline__toggle-section">Open</a>
         </div>
     </div>
     {% endfor %}

--- a/common/templates/components/predictor-timeline/template.njk
+++ b/common/templates/components/predictor-timeline/template.njk
@@ -1,0 +1,18 @@
+{% from "common/templates/components/predictor-timeline-item/macro.njk" import predictorTimelineItem %}
+
+<div class="moj-timeline">
+    {%for item in predictorScores %}    
+    <div class="moj-timeline__item">
+        <div class="moj-timeline__header">
+            <p class="moj-timeline__byline">{{ item.date }}</p>
+        </div>
+        <div class="moj-timeline__description">
+            <ul class="govuk-list">
+                <li>{{ predictorTimelineItem(item.scores.RSR) }}</li>
+                <li>{{ predictorTimelineItem(item.scores.OSPC) }}</li>
+                <li>{{ predictorTimelineItem(item.scores.OSPI) }}</li>
+            </ul>
+        </div>
+    </div>
+    {% endfor %}
+</div>

--- a/common/templates/components/predictor-timeline/template.njk
+++ b/common/templates/components/predictor-timeline/template.njk
@@ -1,18 +1,25 @@
 {% from "common/templates/components/predictor-timeline-item/macro.njk" import predictorTimelineItem %}
 
-<div class="moj-timeline">
-    {%for item in predictorScores %}    
+<div class="moj-timeline predictor">
+    {%for item in predictorScores %}
     <div class="moj-timeline__item">
         <div class="moj-timeline__header">
             <p class="moj-timeline__byline">{{ item.date }}</p>
         </div>
         <div class="moj-timeline__description">
-            <ul class="govuk-list">
-                <li>{{ predictorTimelineItem(item.scores.RSR) }}</li>
-                <li>{{ predictorTimelineItem(item.scores.OSPC) }}</li>
-                <li>{{ predictorTimelineItem(item.scores.OSPI) }}</li>
-            </ul>
+            <div class="predictor-timeline-section">
+                <div>
+                    <ul class="govuk-list">
+                        <li>{{ predictorTimelineItem(item.scores.RSR) }}</li>
+                        <li>{{ predictorTimelineItem(item.scores.OSPC) }}</li>
+                        <li>{{ predictorTimelineItem(item.scores.OSPI) }}</li>
+                    </ul>
+                </div>
+                <a href="#" class="govuk-link predictor-timeline__toggle-section">Open</a>
+            </div>
         </div>
     </div>
     {% endfor %}
 </div>
+
+<script src="/javascripts/predictors.js"></script>

--- a/common/utils/constants.js
+++ b/common/utils/constants.js
@@ -1,9 +1,11 @@
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
 const REFRESH_TOKEN_LIFETIME_SECONDS = 12 * 60 * 60
 const SIXTY_SECONDS = 60
+const ONE_DAY = 86400
 
 module.exports = Object.freeze({
   UUID_REGEX,
   REFRESH_TOKEN_LIFETIME_SECONDS,
   SIXTY_SECONDS,
+  ONE_DAY,
 })

--- a/integration-tests/integration/predictors/predictors.spec.js
+++ b/integration-tests/integration/predictors/predictors.spec.js
@@ -1,0 +1,54 @@
+const PredictorsPage = require('../../pages/predictors/predictorsPage')
+
+const scoreHistoryTimeline = () => cy.get('#predictor-scores-history').find('.predictor-timeline-section')
+
+const headingsIn = elementId => cy.get(`#${elementId}`).find('h2')
+
+context('Predictors page', () => {
+  before(() => {
+    cy.task('stubAssessmentApi')
+  })
+
+  it('Shows predictor scores', () => {
+    PredictorsPage.visit()
+
+    headingsIn('predictor-scores')
+      .should('contain.text', 'RSR score')
+      .should('contain.text', 'OSP/C score')
+      .should('contain.text', 'OSP/I score')
+  })
+
+  it('Allows the user to "Open all" timeline events', () => {
+    PredictorsPage.visit()
+
+    headingsIn('predictor-scores-history').should('contain.text', 'Scores history')
+
+    scoreHistoryTimeline().should('not.to.be.visible')
+
+    cy.contains('a', 'Open all').click()
+
+    scoreHistoryTimeline().should('to.be.visible')
+
+    scoreHistoryTimeline().contains('RSR HIGH')
+    scoreHistoryTimeline().contains('OSP/C MEDIUM')
+    scoreHistoryTimeline().contains('OSP/I LOW')
+  })
+
+  it('Allows the user to "Open" a single timeline event', () => {
+    PredictorsPage.visit()
+
+    scoreHistoryTimeline()
+      .first()
+      .should('not.to.be.visible')
+
+    scoreHistoryTimeline()
+      .first()
+      .parent()
+      .contains('a', 'Open')
+      .click()
+
+    scoreHistoryTimeline()
+      .first()
+      .should('to.be.visible')
+  })
+})

--- a/integration-tests/pages/predictors/predictorsPage.js
+++ b/integration-tests/pages/predictors/predictorsPage.js
@@ -1,0 +1,28 @@
+const page = require('../page')
+
+const predictorsPage = () =>
+  page("Offender's scores", {
+    submit: () => cy.get('.govuk-button').contains('Submit scores to OASys'),
+  })
+
+const needsPage = () => ({
+  questions: () => cy.get('.govuk-form-group'),
+  save: () => cy.get('button').contains('Save and continue'),
+})
+
+export default {
+  verifyOnPage: predictorsPage,
+  visit: () => {
+    cy.visit(`/fb6b7c33-07fc-4c4c-a009-8d60f66952c4/questiongroup/RSR/0/1`)
+    needsPage()
+      .questions()
+      .contains('Have you completed an interview with the individual?')
+      .parent()
+      .find('input') // Have you completed an interview with the individual? (No)
+      .check('NO')
+    needsPage()
+      .save()
+      .click()
+    return predictorsPage
+  },
+}

--- a/wiremock/assessmentApi.js
+++ b/wiremock/assessmentApi.js
@@ -250,7 +250,10 @@ const stubAssessmentEpisodes = () => {
         'Content-Type': 'application/json;charset=UTF-8',
       },
       status: 200,
-      jsonBody: {},
+      jsonBody: {
+        episodeUuid: '22222222-2222-2222-2222-222222222222',
+        predictors: [],
+      },
     },
   })
 }
@@ -263,7 +266,7 @@ const stubQuestions = async () => {
   await stubQuestionGroup('ROSH')
   await stubQuestionGroup('pre_sentence_assessment')
   await stubQuestionGroup('12222222-2222-2222-2222-222222222203')
-  await stubQuestionGroup('rsr_only')
+  await stubQuestionGroup('RSR')
   // await stubAllInternalQuestionGroups(questionGroups['65a3924c-4130-4140-b7f4-cc39a52603bb'])
   // await stubAllInternalQuestionGroups(questionGroups['22222222-2222-2222-2222-222222222203'])
 }
@@ -278,6 +281,7 @@ const stubAssessmentTypeSummaries = async () => {
   await stubAssessmentTypeSummary('65a3924c-4130-4140-b7f4-cc39a52603bb') // short psr
   await stubAssessmentTypeSummary('22222222-2222-2222-2222-222222222203') // brief
   await stubAssessmentTypeSummary('ROSH') // brief
+  await stubAssessmentTypeSummary('RSR') // RSR Only
 }
 const stubAnswers = async () => {
   await stubAnswersGroup(1234)

--- a/wiremock/assessmentApi.js
+++ b/wiremock/assessmentApi.js
@@ -6,6 +6,7 @@ const questionList = require('./responses/questionList.json')
 const assessmentEpisodes = require('./responses/assessmentEpisodes.json')
 const offenderDetails = require('./responses/offenderDetails.json')
 const assessmentSupervision = require('./responses/assessmentSupervision.json')
+const updateEpisode = require('./responses/updateEpisode.json')
 
 const stubGetAssessments = () => {
   stubFor({
@@ -250,10 +251,7 @@ const stubAssessmentEpisodes = () => {
         'Content-Type': 'application/json;charset=UTF-8',
       },
       status: 200,
-      jsonBody: {
-        episodeUuid: '22222222-2222-2222-2222-222222222222',
-        predictors: [],
-      },
+      jsonBody: updateEpisode,
     },
   })
 }

--- a/wiremock/responses/questionGroupSummary.json
+++ b/wiremock/responses/questionGroupSummary.json
@@ -338,5 +338,29 @@
         ]
       }
     ]
+  },
+  "RSR": {
+    "groupId": "b89429c8-9e3e-4989-b886-9caed4ed0a30",
+    "groupCode": "rsr_only",
+    "title": "RSR Only",
+    "contents": [
+      {
+        "groupId": "5d37254e-d956-488e-89be-1eaec8758ef7",
+        "groupCode": "rsr_offences_convictions_needs_risk_to_others",
+        "title": "Offences, convictions, needs and risk to others",
+        "contents": [
+          {
+            "groupId": "eb7b7324-f2a6-4902-91ef-709a8fab1f82",
+            "groupCode": "offences_and_convictions",
+            "title": "Offences and convictions"
+          },
+          {
+            "groupId": "6d3a4377-2177-429e-a7fa-6aa2444d14dd",
+            "groupCode": "rsr_needs",
+            "title": "Needs"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/wiremock/responses/questionGroups.json
+++ b/wiremock/responses/questionGroups.json
@@ -7531,7 +7531,7 @@
       }
     ]
   },
-  "rsr_only": {
+  "RSR": {
     "type": "group",
     "groupId": "b89429c8-9e3e-4989-b886-9caed4ed0a30",
     "groupCode": "rsr_only",
@@ -7540,1047 +7540,1033 @@
       {
         "type": "group",
         "groupId": "5d37254e-d956-488e-89be-1eaec8758ef7",
-        "groupCode": "offences_convictions_needs_risk_to_others",
+        "groupCode": "rsr_offences_convictions_needs_risk_to_others",
         "title": "Offences, convictions, needs and risk to others",
         "displayOrder": 1,
         "mandatory": false,
         "contents": [
           {
             "type": "group",
-            "groupId": "61feebd9-afe5-43ef-94a5-27c400453eba",
-            "groupCode": "offences_convictions_and_needs",
-            "title": "Offences, convictions and needs",
+            "groupId": "eb7b7324-f2a6-4902-91ef-709a8fab1f82",
+            "groupCode": "offences_and_convictions",
+            "title": "Offences and convictions",
             "displayOrder": 1,
             "mandatory": true,
             "contents": [
               {
-                "type": "group",
-                "groupId": "eb7b7324-f2a6-4902-91ef-709a8fab1f82",
-                "groupCode": "offences_and_convictions",
-                "title": "Offences and convictions",
+                "type": "question",
+                "questionId": "0bc681b4-7f70-477e-8ef5-0daaf8aa0495",
+                "questionCode": "ui35.1.1",
+                "answerType": "presentation: heading_large",
+                "questionText": "Main offence",
+                "helpText": "Primary or most serious offence as judged by assessor",
                 "displayOrder": 1,
                 "mandatory": true,
-                "contents": [
-                  {
-                    "type": "question",
-                    "questionId": "0bc681b4-7f70-477e-8ef5-0daaf8aa0495",
-                    "questionCode": "ui35.1.1",
-                    "answerType": "presentation: heading_large",
-                    "questionText": "Main offence",
-                    "helpText": "Primary or most serious offence as judged by assessor",
-                    "displayOrder": 1,
-                    "mandatory": true,
-                    "readOnly": true,
-                    "conditional": false,
-                    "referenceDataTargets": [],
-                    "answerSchemas": []
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "54b03faa-efc0-49ef-9add-7581dca17d70",
-                    "questionCode": "35.1.1",
-                    "answerType": "freetext",
-                    "questionText": "Offence",
-                    "displayOrder": 2,
-                    "mandatory": true,
-                    "readOnly": true,
-                    "conditional": false,
-                    "referenceDataTargets": [],
-                    "answerSchemas": []
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "91c83565-91dc-4876-97d7-f186ce04584c",
-                    "questionCode": "35.1.2",
-                    "answerType": "freetext",
-                    "questionText": "Subcode",
-                    "displayOrder": 3,
-                    "mandatory": true,
-                    "readOnly": true,
-                    "conditional": false,
-                    "referenceDataTargets": [],
-                    "answerSchemas": []
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "de19c962-bd78-428f-ad29-ab002e7ef25a",
-                    "questionCode": "ui35.1.2",
-                    "answerType": "presentation: divider",
-                    "displayOrder": 4,
-                    "mandatory": true,
-                    "readOnly": true,
-                    "conditional": false,
-                    "referenceDataTargets": [],
-                    "answerSchemas": []
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "96d6c7fd-c755-4dad-b3be-8619674c8ad7",
-                    "questionCode": "ui43.1",
-                    "answerType": "presentation: heading_large",
-                    "questionText": "RSR analysis",
-                    "displayOrder": 5,
-                    "mandatory": true,
-                    "readOnly": true,
-                    "conditional": false,
-                    "referenceDataTargets": [],
-                    "answerSchemas": []
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "5ca86a06-5472-4861-bd6a-a011780db49a",
-                    "questionCode": "293.1",
-                    "answerType": "date",
-                    "questionText": "Date of first sanction",
-                    "displayOrder": 6,
-                    "mandatory": true,
-                    "readOnly": false,
-                    "conditional": false,
-                    "referenceDataTargets": [],
-                    "answerSchemas": []
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "63099aab-f852-4dd9-9179-16ee2218d0c6",
-                    "questionCode": "291.2",
-                    "answerType": "numeric",
-                    "questionText": "Age at first conviction, conditional or absolute discharge in years",
-                    "helpText": "Record in years",
-                    "displayOrder": 7,
-                    "mandatory": true,
-                    "readOnly": false,
-                    "conditional": false,
-                    "referenceDataTargets": [],
-                    "answerSchemas": []
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "8e83a0ad-2fcf-4afb-a0af-09d1e23d3c33",
-                    "questionCode": "45.1",
-                    "answerType": "numeric",
-                    "questionText": "Total number of sanctions for all offences",
-                    "displayOrder": 8,
-                    "mandatory": true,
-                    "validation": "{\"mandatory\":{\"errorMessage\":\"Enter the total number of sanctions\",\"errorSummary\":\"Enter the total number of sanctions\"}}",
-                    "readOnly": false,
-                    "conditional": false,
-                    "referenceDataTargets": [],
-                    "answerSchemas": []
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "496587b9-81f3-47ad-a41e-77900fdca573",
-                    "questionCode": "46.1",
-                    "answerType": "numeric",
-                    "questionText": "How many of the total number of sanctions involved violent offences?",
-                    "displayOrder": 9,
-                    "mandatory": true,
-                    "validation": "{\"mandatory\":{\"errorMessage\":\"Say how many sanctions involved violent offences\",\"errorSummary\":\"Say how many sanctions involved violent offences\"}}",
-                    "readOnly": false,
-                    "conditional": false,
-                    "referenceDataTargets": [],
-                    "answerSchemas": []
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "f5d1dd7c-1774-4c76-89c2-a47240ad98ba",
-                    "questionCode": "48.1",
-                    "answerType": "date",
-                    "questionText": "Date of current conviction",
-                    "helpText": "For example, 12 11 2007",
-                    "displayOrder": 10,
-                    "mandatory": true,
-                    "readOnly": false,
-                    "conditional": false,
-                    "referenceDataTargets": [],
-                    "answerSchemas": []
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "58d3efd1-65a1-439b-952f-b2826ffa5e71",
-                    "questionCode": "59.1",
-                    "answerType": "radio",
-                    "questionText": "Have they ever committed a sexual offence?",
-                    "displayOrder": 11,
-                    "mandatory": true,
-                    "validation": "{\"mandatory\":{\"errorMessage\":\"Select yes or no\",\"errorSummary\":\"Select yes or no (sexual or sexually-motivated offence)\"}}",
-                    "readOnly": false,
-                    "conditional": false,
-                    "referenceDataTargets": [],
-                    "answerSchemas": [
-                      {
-                        "answerSchemaUuid": "0d4682ab-7b24-4527-b0b3-b4d520e7c2d8",
-                        "answerSchemaCode": "yes",
-                        "value": "YES",
-                        "text": "Yes",
-                        "conditionals": [
-                          {
-                            "conditional": "3662710d-ce3e-4e45-bce3-caa4155872aa",
-                            "displayInline": true
-                          },
-                          {
-                            "conditional": "a00223d0-1c20-43b5-8076-8a292ca25773",
-                            "displayInline": true
-                          },
-                          {
-                            "conditional": "fc45b061-a4a6-44c3-937c-2949069e0926",
-                            "displayInline": true
-                          },
-                          {
-                            "conditional": "ed495c57-21f3-4388-87e6-57017a6999b1",
-                            "displayInline": true
-                          },
-                          {
-                            "conditional": "00a559e4-32d5-4ae7-aa21-247068a639ad",
-                            "displayInline": true
-                          },
-                          {
-                            "conditional": "1b6c8f79-0fd9-45d4-ba50-309c3ccfdb2d",
-                            "displayInline": true
-                          }
-                        ]
-                      },
-                      {
-                        "answerSchemaUuid": "2a6011b2-4973-4249-99fd-9f84dbb2c88e",
-                        "answerSchemaCode": "no",
-                        "value": "NO",
-                        "text": "No"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "3662710d-ce3e-4e45-bce3-caa4155872aa",
-                    "questionCode": "292.1",
-                    "answerType": "radio",
-                    "questionText": "Does the current offence have a sexual motivation?",
-                    "displayOrder": 12,
-                    "mandatory": true,
-                    "validation": "{\"mandatory\":{\"errorMessage\":\"Select yes or no\",\"errorSummary\":\"Select yes or no (current sexual offence)\"}}",
-                    "readOnly": false,
-                    "conditional": true,
-                    "referenceDataTargets": [],
-                    "answerSchemas": [
-                      {
-                        "answerSchemaUuid": "0d4682ab-7b24-4527-b0b3-b4d520e7c2d8",
-                        "answerSchemaCode": "yes",
-                        "value": "YES",
-                        "text": "Yes",
-                        "conditionals": [
-                          {
-                            "conditional": "86ee742c-4bfb-4e29-afca-04ad35a3abda",
-                            "displayInline": true
-                          }
-                        ]
-                      },
-                      {
-                        "answerSchemaUuid": "2a6011b2-4973-4249-99fd-9f84dbb2c88e",
-                        "answerSchemaCode": "no",
-                        "value": "NO",
-                        "text": "No"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "86ee742c-4bfb-4e29-afca-04ad35a3abda",
-                    "questionCode": "61.1",
-                    "answerType": "radio",
-                    "questionText": "Does the current offence involve a victim who was a stranger?",
-                    "displayOrder": 13,
-                    "mandatory": true,
-                    "validation": "{\"mandatory\":{\"errorMessage\":\"Select yes or no\",\"errorSummary\":\"Select yes or no (contact against a stranger victim)\"}}",
-                    "readOnly": false,
-                    "conditional": true,
-                    "referenceDataTargets": [],
-                    "answerSchemas": [
-                      {
-                        "answerSchemaUuid": "0d4682ab-7b24-4527-b0b3-b4d520e7c2d8",
-                        "answerSchemaCode": "yes",
-                        "value": "YES",
-                        "text": "Yes"
-                      },
-                      {
-                        "answerSchemaUuid": "2a6011b2-4973-4249-99fd-9f84dbb2c88e",
-                        "answerSchemaCode": "no",
-                        "value": "NO",
-                        "text": "No"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "a00223d0-1c20-43b5-8076-8a292ca25773",
-                    "questionCode": "62.1",
-                    "answerType": "date",
-                    "questionText": "Date of most recent sanction involving a sexual or sexually motivated offence",
-                    "helpText": "For example, 12 11 2007",
-                    "displayOrder": 14,
-                    "mandatory": true,
-                    "validation": "{\"mandatory\":{\"errorMessage\":\"Enter the date of the most recent sanction involving a sexual or sexually motivated offence\",\"errorSummary\":\"Enter the date of the most recent sanction involving a sexual or sexually motivated offence\"}}",
-                    "readOnly": false,
-                    "conditional": true,
-                    "referenceDataTargets": [],
-                    "answerSchemas": []
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "fc45b061-a4a6-44c3-937c-2949069e0926",
-                    "questionCode": "63.1",
-                    "answerType": "numeric",
-                    "questionText": "Number of previous or current sanctions involving contact adult sexual or sexually motivated offences",
-                    "displayOrder": 15,
-                    "mandatory": true,
-                    "validation": "{\"mandatory\":{\"errorMessage\":\"Enter the number of previous or current sanctions involving contact adult sexual or sexually motivated offences\",\"errorSummary\":\"Enter the number of previous or current sanctions involving contact adult sexual or sexually motivated offences\"}}",
-                    "readOnly": false,
-                    "conditional": true,
-                    "referenceDataTargets": [],
-                    "answerSchemas": []
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "ed495c57-21f3-4388-87e6-57017a6999b1",
-                    "questionCode": "64.1",
-                    "answerType": "numeric",
-                    "questionText": "Number of previous or current sanctions involving contact child sexual or sexually motivated offences",
-                    "displayOrder": 16,
-                    "mandatory": true,
-                    "validation": "{\"mandatory\":{\"errorMessage\":\"Enter the number of previous or current sanctions involving contact child sexual or sexually offences\",\"errorSummary\":\"Enter the number of previous or current sanctions involving contact child sexual or sexually motivated offences\"}}",
-                    "readOnly": false,
-                    "conditional": true,
-                    "referenceDataTargets": [],
-                    "answerSchemas": []
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "00a559e4-32d5-4ae7-aa21-247068a639ad",
-                    "questionCode": "65.1",
-                    "answerType": "numeric",
-                    "questionText": "Number of previous or current sanctions involving indecent child image sexual or sexually motivated offences",
-                    "displayOrder": 17,
-                    "mandatory": true,
-                    "validation": "{\"mandatory\":{\"errorMessage\":\"Enter the number of previous or current sanctions involving indecent child image sexual or sexually motivated offences\",\"errorSummary\":\"Enter the number of previous or current sanctions involving indecent child image sexual or sexually motivated offences\"}}",
-                    "readOnly": false,
-                    "conditional": true,
-                    "referenceDataTargets": [],
-                    "answerSchemas": []
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "1b6c8f79-0fd9-45d4-ba50-309c3ccfdb2d",
-                    "questionCode": "66.1",
-                    "answerType": "numeric",
-                    "questionText": "Number of previous or current sanctions involving other non-contact sexual or sexually motivated offences",
-                    "displayOrder": 18,
-                    "mandatory": true,
-                    "validation": "{\"mandatory\":{\"errorMessage\":\"Enter the number of previous or current sanctions involving other non-contact sexual or sexually motivated offences\",\"errorSummary\":\"Number of previous or current sanctions involving other non-contact sexual or sexually motivated offences\"}}",
-                    "readOnly": false,
-                    "conditional": true,
-                    "referenceDataTargets": [],
-                    "answerSchemas": []
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "5cd344d4-acf3-45a9-9493-5dda5aa9dfa8",
-                    "questionCode": "60.1",
-                    "answerType": "date",
-                    "questionText": "Date of commencement of community sentence or earliest possible release from custody",
-                    "helpText": "For example, 12 11 2007",
-                    "displayOrder": 19,
-                    "mandatory": true,
-                    "validation": "{\"mandatory\":{\"errorMessage\":\"Enter a date\",\"errorSummary\":\"Enter a date\"}}",
-                    "readOnly": false,
-                    "conditional": false,
-                    "referenceDataTargets": [],
-                    "answerSchemas": []
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "420c2ffe-8f2c-49b3-a523-674af3197b9e",
-                    "questionCode": "67.1",
-                    "answerType": "radio",
-                    "questionText": "Have you completed an interview with the individual?",
-                    "displayOrder": 20,
-                    "mandatory": true,
-                    "validation": "{\"mandatory\":{\"errorMessage\":\"Select yes or no\",\"errorSummary\":\"Select yes or no (completed an interview with the individual)\"}}",
-                    "readOnly": false,
-                    "conditional": false,
-                    "referenceDataTargets": [],
-                    "answerSchemas": [
-                      {
-                        "answerSchemaUuid": "0d4682ab-7b24-4527-b0b3-b4d520e7c2d8",
-                        "answerSchemaCode": "yes",
-                        "value": "YES",
-                        "text": "Yes",
-                        "conditionals": [
-                          {
-                            "conditional": "bd629547-eab9-46d5-910d-2416b431950f",
-                            "displayInline": false
-                          },
-                          {
-                            "conditional": "ed0e988a-38a4-4f9f-9691-08fb695cbed9",
-                            "displayInline": false
-                          },
-                          {
-                            "conditional": "3211a668-8878-4e88-8457-8250bfe65aea",
-                            "displayInline": false
-                          },
-                          {
-                            "conditional": "1970ba5e-91cb-4ad3-9f04-64d5b5b7157b",
-                            "displayInline": false
-                          },
-                          {
-                            "conditional": "f04dd882-0a0d-49f5-9736-91eeadbff9e7",
-                            "displayInline": false
-                          },
-                          {
-                            "conditional": "fb98f8b1-58ed-4aac-85b1-404f84270b95",
-                            "displayInline": false
-                          },
-                          {
-                            "conditional": "38b3a40a-df23-4ea1-872e-c04a8b03ee05",
-                            "displayInline": false
-                          },
-                          {
-                            "conditional": "f0416e89-3a71-46d1-8fa2-aebd886dcb34",
-                            "displayInline": false
-                          },
-                          {
-                            "conditional": "574618c3-27f4-4dd2-94bb-6de74126ff22",
-                            "displayInline": false
-                          },
-                          {
-                            "conditional": "5a90a38d-ee0a-4775-994c-addf3397b817",
-                            "displayInline": false
-                          },
-                          {
-                            "conditional": "d0619e6b-cc90-4031-90c6-ab15e06cc779",
-                            "displayInline": false
-                          }
-                        ]
-                      },
-                      {
-                        "answerSchemaUuid": "2a6011b2-4973-4249-99fd-9f84dbb2c88e",
-                        "answerSchemaCode": "no",
-                        "value": "NO",
-                        "text": "No"
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "group",
-                "groupId": "ebf96a74-c140-47d8-b37f-62cff68f41c0",
-                "groupCode": "needs",
-                "title": "Needs",
-                "displayOrder": 2,
-                "mandatory": true,
-                "contents": [
-                  {
-                    "type": "question",
-                    "questionId": "bd629547-eab9-46d5-910d-2416b431950f",
-                    "questionCode": "69.1",
-                    "answerType": "radio",
-                    "questionText": "Did the offence involve carrying or use of a weapon?",
-                    "displayOrder": 1,
-                    "mandatory": true,
-                    "validation": "{\"mandatory\":{\"errorMessage\":\"Select yes or no\",\"errorSummary\":\"Select yes or no (carrying or using weapon)\"}}",
-                    "readOnly": false,
-                    "conditional": true,
-                    "referenceDataTargets": [],
-                    "answerSchemas": [
-                      {
-                        "answerSchemaUuid": "0d4682ab-7b24-4527-b0b3-b4d520e7c2d8",
-                        "answerSchemaCode": "yes",
-                        "value": "YES",
-                        "text": "Yes",
-                        "conditionals": [
-                          {
-                            "conditional": "7f076a91-2702-438f-81ba-c15ebfab1b02",
-                            "displayInline": true
-                          }
-                        ]
-                      },
-                      {
-                        "answerSchemaUuid": "2a6011b2-4973-4249-99fd-9f84dbb2c88e",
-                        "answerSchemaCode": "no",
-                        "value": "NO",
-                        "text": "No"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "7f076a91-2702-438f-81ba-c15ebfab1b02",
-                    "questionCode": "70.1",
-                    "answerType": "freetext",
-                    "questionText": "Specify which weapon",
-                    "displayOrder": 2,
-                    "mandatory": true,
-                    "validation": "{\"mandatory\":{\"errorMessage\":\"Specify a weapon\",\"errorSummary\":\"Specify a weapon\"}}",
-                    "readOnly": false,
-                    "conditional": true,
-                    "referenceDataTargets": [],
-                    "answerSchemas": []
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "ed0e988a-38a4-4f9f-9691-08fb695cbed9",
-                    "questionCode": "75.1",
-                    "answerType": "radio",
-                    "questionText": "Is the individual living in suitable accommodation?",
-                    "displayOrder": 3,
-                    "mandatory": true,
-                    "validation": "{\"mandatory\":{\"errorMessage\":\"Select the degree to which this is an issue\",\"errorSummary\":\"Select the degree to which this is an issue (suitability of accommodation)\"}}",
-                    "readOnly": false,
-                    "conditional": true,
-                    "referenceDataTargets": [],
-                    "answerSchemas": [
-                      {
-                        "answerSchemaUuid": "2dbde741-36ef-44b7-af79-fabdbf3e62c3",
-                        "answerSchemaCode": "no_problems",
-                        "value": "no problems",
-                        "text": "No problems"
-                      },
-                      {
-                        "answerSchemaUuid": "80cbb013-5633-44ca-b407-87fdde95652d",
-                        "answerSchemaCode": "some_problems",
-                        "value": "some problems",
-                        "text": "Some problems"
-                      },
-                      {
-                        "answerSchemaUuid": "2df8f5e2-7d04-41a4-a13f-f9df7479c775",
-                        "answerSchemaCode": "significant_problems",
-                        "value": "significant problems",
-                        "text": "Significant problems"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "3211a668-8878-4e88-8457-8250bfe65aea",
-                    "questionCode": "80.1",
-                    "answerType": "radio",
-                    "questionText": "Is the person unemployed or will be unemployed upon release?",
-                    "displayOrder": 4,
-                    "mandatory": true,
-                    "validation": "{\"mandatory\":{\"errorMessage\":\"Select an option\",\"errorSummary\":\"Enter yes or no (unemployed now or on release)\"}}",
-                    "readOnly": false,
-                    "conditional": true,
-                    "referenceDataTargets": [],
-                    "answerSchemas": [
-                      {
-                        "answerSchemaUuid": "d4c6ed05-73b4-4064-8255-7ccb96038988",
-                        "answerSchemaCode": "no",
-                        "value": "no",
-                        "text": "No"
-                      },
-                      {
-                        "answerSchemaUuid": "02c77c0c-f9fa-4c4c-a5dc-169aa33f5c86",
-                        "answerSchemaCode": "not_available_for_work",
-                        "value": "not available for work",
-                        "text": "Not available for work"
-                      },
-                      {
-                        "answerSchemaUuid": "f2619d17-2bda-40ce-9658-f6a7a371b3f2",
-                        "answerSchemaCode": "yes",
-                        "value": "yes",
-                        "text": "Yes"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "1970ba5e-91cb-4ad3-9f04-64d5b5b7157b",
-                    "questionCode": "86.1",
-                    "answerType": "radio",
-                    "questionText": "What is the person's current relationship with their partner?",
-                    "displayOrder": 5,
-                    "mandatory": true,
-                    "validation": "{\"mandatory\":{\"errorMessage\":\"Select the degree to which this is an issue\",\"errorSummary\":\"Select the degree to which this is an issue (current relationship with partner)\"}}",
-                    "readOnly": false,
-                    "conditional": true,
-                    "referenceDataTargets": [],
-                    "answerSchemas": [
-                      {
-                        "answerSchemaUuid": "2dbde741-36ef-44b7-af79-fabdbf3e62c3",
-                        "answerSchemaCode": "no_problems",
-                        "value": "no problems",
-                        "text": "No problems"
-                      },
-                      {
-                        "answerSchemaUuid": "80cbb013-5633-44ca-b407-87fdde95652d",
-                        "answerSchemaCode": "some_problems",
-                        "value": "some problems",
-                        "text": "Some problems"
-                      },
-                      {
-                        "answerSchemaUuid": "2df8f5e2-7d04-41a4-a13f-f9df7479c775",
-                        "answerSchemaCode": "significant_problems",
-                        "value": "significant problems",
-                        "text": "Significant problems"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "f04dd882-0a0d-49f5-9736-91eeadbff9e7",
-                    "questionCode": "87.1",
-                    "answerType": "radio",
-                    "questionText": "Is there evidence that the individual is a perpetrator of domestic abuse?",
-                    "displayOrder": 6,
-                    "mandatory": true,
-                    "validation": "{\"mandatory\":{\"errorMessage\":\"Select yes or no\",\"errorSummary\":\"Select yes or no (perpetrator of domestic  abuse?)\"}}",
-                    "readOnly": false,
-                    "conditional": true,
-                    "referenceDataTargets": [],
-                    "answerSchemas": [
-                      {
-                        "answerSchemaUuid": "0d4682ab-7b24-4527-b0b3-b4d520e7c2d8",
-                        "answerSchemaCode": "yes",
-                        "value": "YES",
-                        "text": "Yes",
-                        "conditionals": [
-                          {
-                            "conditional": "fb98f8b1-58ed-4aac-85b1-404f84270b95",
-                            "displayInline": true
-                          },
-                          {
-                            "conditional": "38b3a40a-df23-4ea1-872e-c04a8b03ee05",
-                            "displayInline": true
-                          }
-                        ]
-                      },
-                      {
-                        "answerSchemaUuid": "2a6011b2-4973-4249-99fd-9f84dbb2c88e",
-                        "answerSchemaCode": "no",
-                        "value": "NO",
-                        "text": "No"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "fb98f8b1-58ed-4aac-85b1-404f84270b95",
-                    "questionCode": "88.1",
-                    "answerType": "checkbox",
-                    "questionText": "Victim",
-                    "displayOrder": 7,
-                    "mandatory": false,
-                    "readOnly": false,
-                    "conditional": true,
-                    "referenceDataTargets": [],
-                    "answerSchemas": [
-                      {
-                        "answerSchemaUuid": "4b6d2415-b152-4ba0-b030-1d203b5b31dc",
-                        "answerSchemaCode": "victim",
-                        "value": "victim",
-                        "text": "Victim"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "38b3a40a-df23-4ea1-872e-c04a8b03ee05",
-                    "questionCode": "88.2",
-                    "answerType": "checkbox",
-                    "questionText": "Perpetrator",
-                    "displayOrder": 8,
-                    "mandatory": false,
-                    "readOnly": false,
-                    "conditional": true,
-                    "referenceDataTargets": [],
-                    "answerSchemas": [
-                      {
-                        "answerSchemaUuid": "9a52b4dd-5648-41d3-8d0d-171228d98474",
-                        "answerSchemaCode": "perpetrator",
-                        "value": "perpetrator",
-                        "text": "Perpetrator"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "f0416e89-3a71-46d1-8fa2-aebd886dcb34",
-                    "questionCode": "90.1",
-                    "answerType": "radio",
-                    "questionText": "Is the person's current use of alcohol a problem?",
-                    "displayOrder": 9,
-                    "mandatory": true,
-                    "validation": "{\"mandatory\":{\"errorMessage\":\"Select the degree to which this is an issue\",\"errorSummary\":\"Select the degree to which this is an issue (current use of alcohol)\"}}",
-                    "readOnly": false,
-                    "conditional": true,
-                    "referenceDataTargets": [],
-                    "answerSchemas": [
-                      {
-                        "answerSchemaUuid": "2dbde741-36ef-44b7-af79-fabdbf3e62c3",
-                        "answerSchemaCode": "no_problems",
-                        "value": "no problems",
-                        "text": "No problems"
-                      },
-                      {
-                        "answerSchemaUuid": "80cbb013-5633-44ca-b407-87fdde95652d",
-                        "answerSchemaCode": "some_problems",
-                        "value": "some problems",
-                        "text": "Some problems"
-                      },
-                      {
-                        "answerSchemaUuid": "2df8f5e2-7d04-41a4-a13f-f9df7479c775",
-                        "answerSchemaCode": "significant_problems",
-                        "value": "significant problems",
-                        "text": "Significant problems"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "574618c3-27f4-4dd2-94bb-6de74126ff22",
-                    "questionCode": "92.1",
-                    "answerType": "radio",
-                    "questionText": "Is there evidence of binge drinking or excessive use of alcohol in the last 6 months?",
-                    "displayOrder": 10,
-                    "mandatory": true,
-                    "validation": "{\"mandatory\":{\"errorMessage\":\"Select the degree to which this is an issue\",\"errorSummary\":\"Select the degree to which this is an issue (evidence of binge drinking or excessive alcohol use)\"}}",
-                    "readOnly": false,
-                    "conditional": true,
-                    "referenceDataTargets": [],
-                    "answerSchemas": [
-                      {
-                        "answerSchemaUuid": "2dbde741-36ef-44b7-af79-fabdbf3e62c3",
-                        "answerSchemaCode": "no_problems",
-                        "value": "no problems",
-                        "text": "No problems"
-                      },
-                      {
-                        "answerSchemaUuid": "80cbb013-5633-44ca-b407-87fdde95652d",
-                        "answerSchemaCode": "some_problems",
-                        "value": "some problems",
-                        "text": "Some problems"
-                      },
-                      {
-                        "answerSchemaUuid": "2df8f5e2-7d04-41a4-a13f-f9df7479c775",
-                        "answerSchemaCode": "significant_problems",
-                        "value": "significant problems",
-                        "text": "Significant problems"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "5a90a38d-ee0a-4775-994c-addf3397b817",
-                    "questionCode": "113.1",
-                    "answerType": "radio",
-                    "questionText": "Is impulsivity a problem for the individual?",
-                    "displayOrder": 11,
-                    "mandatory": true,
-                    "validation": "{\"mandatory\":{\"errorMessage\":\"Select the degree to which this is an issue\",\"errorSummary\":\"Select the degree to which this is an issue (impulsivity)\"}}",
-                    "readOnly": false,
-                    "conditional": true,
-                    "referenceDataTargets": [],
-                    "answerSchemas": [
-                      {
-                        "answerSchemaUuid": "2dbde741-36ef-44b7-af79-fabdbf3e62c3",
-                        "answerSchemaCode": "no_problems",
-                        "value": "no problems",
-                        "text": "No problems"
-                      },
-                      {
-                        "answerSchemaUuid": "80cbb013-5633-44ca-b407-87fdde95652d",
-                        "answerSchemaCode": "some_problems",
-                        "value": "some problems",
-                        "text": "Some problems"
-                      },
-                      {
-                        "answerSchemaUuid": "2df8f5e2-7d04-41a4-a13f-f9df7479c775",
-                        "answerSchemaCode": "significant_problems",
-                        "value": "significant problems",
-                        "text": "Significant problems"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "question",
-                    "questionId": "d0619e6b-cc90-4031-90c6-ab15e06cc779",
-                    "questionCode": "115.1",
-                    "answerType": "radio",
-                    "questionText": "Is temper control a problem for the individual?",
-                    "displayOrder": 12,
-                    "mandatory": true,
-                    "validation": "{\"mandatory\":{\"errorMessage\":\"Select the degree to which this is an issue\",\"errorSummary\":\"Select the degree to which this is an issue (temper control)\"}}",
-                    "readOnly": false,
-                    "conditional": true,
-                    "referenceDataTargets": [],
-                    "answerSchemas": [
-                      {
-                        "answerSchemaUuid": "2dbde741-36ef-44b7-af79-fabdbf3e62c3",
-                        "answerSchemaCode": "no_problems",
-                        "value": "no problems",
-                        "text": "No problems"
-                      },
-                      {
-                        "answerSchemaUuid": "80cbb013-5633-44ca-b407-87fdde95652d",
-                        "answerSchemaCode": "some_problems",
-                        "value": "some problems",
-                        "text": "Some problems"
-                      },
-                      {
-                        "answerSchemaUuid": "2df8f5e2-7d04-41a4-a13f-f9df7479c775",
-                        "answerSchemaCode": "significant_problems",
-                        "value": "significant problems",
-                        "text": "Significant problems"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "type": "group",
-            "groupId": "91a60f48-89d4-4106-8f8a-fe797edca111",
-            "groupCode": "rsr_only_risk_to_others",
-            "title": "Risk to others",
-            "displayOrder": 2,
-            "mandatory": true,
-            "contents": [
-              {
-                "type": "question",
-                "questionId": "0941c5b2-f42d-4120-ad79-44954674fe00",
-                "questionCode": "130.1",
-                "answerType": "inline-checkbox",
-                "questionText": "Murder/attempted murder/threat or conspiracy to murder/manslaughter",
-                "displayOrder": 1,
-                "mandatory": true,
-                "readOnly": false,
+                "readOnly": true,
                 "conditional": false,
                 "referenceDataTargets": [],
-                "answerSchemas": [
-                  {
-                    "answerSchemaUuid": "7846b56e-5004-47db-a59d-a84c85d7b69a",
-                    "answerSchemaCode": "previous_conviction",
-                    "value": "YES",
-                    "text": "Previous conviction"
-                  }
-                ]
+                "answerSchemas": []
               },
               {
                 "type": "question",
-                "questionId": "f988f76c-3d6c-4f45-aa29-7dc8d11198d7",
-                "questionCode": "131.1",
-                "answerType": "checkbox",
-                "questionText": "Wounding/GBH (Sections 18/20 Offences Against the Person Act 1861)",
+                "questionId": "54b03faa-efc0-49ef-9add-7581dca17d70",
+                "questionCode": "35.1.1",
+                "answerType": "freetext",
+                "questionText": "Offence",
                 "displayOrder": 2,
                 "mandatory": true,
-                "readOnly": false,
+                "readOnly": true,
                 "conditional": false,
                 "referenceDataTargets": [],
-                "answerSchemas": [
-                  {
-                    "answerSchemaUuid": "7846b56e-5004-47db-a59d-a84c85d7b69a",
-                    "answerSchemaCode": "previous_conviction",
-                    "value": "YES",
-                    "text": "Previous conviction"
-                  }
-                ]
+                "answerSchemas": []
               },
               {
                 "type": "question",
-                "questionId": "ad81d270-4acc-472c-a79e-01d0a422ce80",
-                "questionCode": "135.1",
-                "answerType": "checkbox",
-                "questionText": "Aggravated burglary",
+                "questionId": "91c83565-91dc-4876-97d7-f186ce04584c",
+                "questionCode": "35.1.2",
+                "answerType": "freetext",
+                "questionText": "Subcode",
                 "displayOrder": 3,
                 "mandatory": true,
-                "readOnly": false,
+                "readOnly": true,
                 "conditional": false,
                 "referenceDataTargets": [],
-                "answerSchemas": [
-                  {
-                    "answerSchemaUuid": "7846b56e-5004-47db-a59d-a84c85d7b69a",
-                    "answerSchemaCode": "previous_conviction",
-                    "value": "YES",
-                    "text": "Previous conviction"
-                  }
-                ]
+                "answerSchemas": []
               },
               {
                 "type": "question",
-                "questionId": "f8789074-1532-4b32-8995-780da18e273a",
-                "questionCode": "136.1",
-                "answerType": "checkbox",
-                "questionText": "Arson",
+                "questionId": "de19c962-bd78-428f-ad29-ab002e7ef25a",
+                "questionCode": "ui35.1.2",
+                "answerType": "presentation: divider",
                 "displayOrder": 4,
                 "mandatory": true,
-                "readOnly": false,
+                "readOnly": true,
                 "conditional": false,
                 "referenceDataTargets": [],
-                "answerSchemas": [
-                  {
-                    "answerSchemaUuid": "7846b56e-5004-47db-a59d-a84c85d7b69a",
-                    "answerSchemaCode": "previous_conviction",
-                    "value": "YES",
-                    "text": "Previous conviction"
-                  }
-                ]
+                "answerSchemas": []
               },
               {
                 "type": "question",
-                "questionId": "df5d635a-6765-42af-9007-6d6d333da5f2",
-                "questionCode": "137.1",
-                "answerType": "checkbox",
-                "questionText": "Criminal damage with intent to endanger life",
+                "questionId": "96d6c7fd-c755-4dad-b3be-8619674c8ad7",
+                "questionCode": "ui43.1",
+                "answerType": "presentation: heading_large",
+                "questionText": "RSR analysis",
                 "displayOrder": 5,
                 "mandatory": true,
-                "readOnly": false,
+                "readOnly": true,
                 "conditional": false,
                 "referenceDataTargets": [],
-                "answerSchemas": [
-                  {
-                    "answerSchemaUuid": "7846b56e-5004-47db-a59d-a84c85d7b69a",
-                    "answerSchemaCode": "previous_conviction",
-                    "value": "YES",
-                    "text": "Previous conviction"
-                  }
-                ]
+                "answerSchemas": []
               },
               {
                 "type": "question",
-                "questionId": "ee2763b4-fff9-42c3-a784-6e6fe6b1dea9",
-                "questionCode": "132.1",
-                "answerType": "checkbox",
-                "questionText": "Any sexual offence against a child",
+                "questionId": "5ca86a06-5472-4861-bd6a-a011780db49a",
+                "questionCode": "293.1",
+                "answerType": "date",
+                "questionText": "Date of first sanction",
                 "displayOrder": 6,
                 "mandatory": true,
                 "readOnly": false,
                 "conditional": false,
                 "referenceDataTargets": [],
-                "answerSchemas": [
-                  {
-                    "answerSchemaUuid": "7846b56e-5004-47db-a59d-a84c85d7b69a",
-                    "answerSchemaCode": "previous_conviction",
-                    "value": "YES",
-                    "text": "Previous conviction"
-                  }
-                ]
+                "answerSchemas": []
               },
               {
                 "type": "question",
-                "questionId": "06d5f00f-a5db-4cc5-b51e-a8c91e63686f",
-                "questionCode": "133.1",
-                "answerType": "checkbox",
-                "questionText": "Rape or serious sexual offence against an adult",
+                "questionId": "63099aab-f852-4dd9-9179-16ee2218d0c6",
+                "questionCode": "291.2",
+                "answerType": "numeric",
+                "questionText": "Age at first conviction, conditional or absolute discharge in years",
+                "helpText": "Record in years",
                 "displayOrder": 7,
                 "mandatory": true,
                 "readOnly": false,
                 "conditional": false,
                 "referenceDataTargets": [],
-                "answerSchemas": [
-                  {
-                    "answerSchemaUuid": "7846b56e-5004-47db-a59d-a84c85d7b69a",
-                    "answerSchemaCode": "previous_conviction",
-                    "value": "YES",
-                    "text": "Previous conviction"
-                  }
-                ]
+                "answerSchemas": []
               },
               {
                 "type": "question",
-                "questionId": "0dcc92ff-20d4-4ee1-b3d7-b124b6f32ae8",
-                "questionCode": "134.1",
-                "answerType": "checkbox",
-                "questionText": "Any other offence against a child",
+                "questionId": "8e83a0ad-2fcf-4afb-a0af-09d1e23d3c33",
+                "questionCode": "45.1",
+                "answerType": "numeric",
+                "questionText": "Total number of sanctions for all offences",
                 "displayOrder": 8,
                 "mandatory": true,
+                "validation": "{\"mandatory\":{\"errorMessage\":\"Enter the total number of sanctions\",\"errorSummary\":\"Enter the total number of sanctions\"}}",
                 "readOnly": false,
                 "conditional": false,
                 "referenceDataTargets": [],
-                "answerSchemas": [
-                  {
-                    "answerSchemaUuid": "7846b56e-5004-47db-a59d-a84c85d7b69a",
-                    "answerSchemaCode": "previous_conviction",
-                    "value": "YES",
-                    "text": "Previous conviction"
-                  }
-                ]
+                "answerSchemas": []
               },
               {
                 "type": "question",
-                "questionId": "c2b221b4-ee1f-41c8-8fc7-9d49998fab35",
-                "questionCode": "138.1",
-                "answerType": "checkbox",
-                "questionText": "Kidnapping/false imprisonment",
+                "questionId": "496587b9-81f3-47ad-a41e-77900fdca573",
+                "questionCode": "46.1",
+                "answerType": "numeric",
+                "questionText": "How many of the total number of sanctions involved violent offences?",
                 "displayOrder": 9,
                 "mandatory": true,
+                "validation": "{\"mandatory\":{\"errorMessage\":\"Say how many sanctions involved violent offences\",\"errorSummary\":\"Say how many sanctions involved violent offences\"}}",
                 "readOnly": false,
                 "conditional": false,
                 "referenceDataTargets": [],
-                "answerSchemas": [
-                  {
-                    "answerSchemaUuid": "7846b56e-5004-47db-a59d-a84c85d7b69a",
-                    "answerSchemaCode": "previous_conviction",
-                    "value": "YES",
-                    "text": "Previous conviction"
-                  }
-                ]
+                "answerSchemas": []
               },
               {
                 "type": "question",
-                "questionId": "e887bcea-91d1-4c50-a25e-4335fa1e6ae5",
-                "questionCode": "139.1",
-                "answerType": "checkbox",
-                "questionText": "Possession of a firearm with intent to endanger life or resist arrest",
+                "questionId": "f5d1dd7c-1774-4c76-89c2-a47240ad98ba",
+                "questionCode": "48.1",
+                "answerType": "date",
+                "questionText": "Date of current conviction",
+                "helpText": "For example, 12 11 2007",
                 "displayOrder": 10,
                 "mandatory": true,
                 "readOnly": false,
                 "conditional": false,
                 "referenceDataTargets": [],
-                "answerSchemas": [
-                  {
-                    "answerSchemaUuid": "7846b56e-5004-47db-a59d-a84c85d7b69a",
-                    "answerSchemaCode": "previous_conviction",
-                    "value": "YES",
-                    "text": "Previous conviction"
-                  }
-                ]
+                "answerSchemas": []
               },
               {
                 "type": "question",
-                "questionId": "9692659a-778a-436a-bf4e-fe1924638e37",
-                "questionCode": "141.1",
-                "answerType": "checkbox",
-                "questionText": "Robbery",
+                "questionId": "58d3efd1-65a1-439b-952f-b2826ffa5e71",
+                "questionCode": "59.1",
+                "answerType": "radio",
+                "questionText": "Have they ever committed a sexual offence?",
                 "displayOrder": 11,
                 "mandatory": true,
+                "validation": "{\"mandatory\":{\"errorMessage\":\"Select yes or no\",\"errorSummary\":\"Select yes or no (sexual or sexually-motivated offence)\"}}",
                 "readOnly": false,
                 "conditional": false,
                 "referenceDataTargets": [],
                 "answerSchemas": [
                   {
-                    "answerSchemaUuid": "7846b56e-5004-47db-a59d-a84c85d7b69a",
-                    "answerSchemaCode": "previous_conviction",
+                    "answerSchemaUuid": "0d4682ab-7b24-4527-b0b3-b4d520e7c2d8",
+                    "answerSchemaCode": "yes",
                     "value": "YES",
-                    "text": "Previous conviction"
+                    "text": "Yes",
+                    "conditionals": [
+                      {
+                        "conditional": "3662710d-ce3e-4e45-bce3-caa4155872aa",
+                        "displayInline": true
+                      },
+                      {
+                        "conditional": "a00223d0-1c20-43b5-8076-8a292ca25773",
+                        "displayInline": true
+                      },
+                      {
+                        "conditional": "fc45b061-a4a6-44c3-937c-2949069e0926",
+                        "displayInline": true
+                      },
+                      {
+                        "conditional": "ed495c57-21f3-4388-87e6-57017a6999b1",
+                        "displayInline": true
+                      },
+                      {
+                        "conditional": "00a559e4-32d5-4ae7-aa21-247068a639ad",
+                        "displayInline": true
+                      },
+                      {
+                        "conditional": "1b6c8f79-0fd9-45d4-ba50-309c3ccfdb2d",
+                        "displayInline": true
+                      }
+                    ]
+                  },
+                  {
+                    "answerSchemaUuid": "2a6011b2-4973-4249-99fd-9f84dbb2c88e",
+                    "answerSchemaCode": "no",
+                    "value": "NO",
+                    "text": "No"
                   }
                 ]
               },
               {
                 "type": "question",
-                "questionId": "68e31f3a-5175-47e2-986b-d722ad78d893",
-                "questionCode": "142.1",
-                "answerType": "checkbox",
-                "questionText": "Any other offence involving possession and/or use of weapons",
+                "questionId": "3662710d-ce3e-4e45-bce3-caa4155872aa",
+                "questionCode": "292.1",
+                "answerType": "radio",
+                "questionText": "Does the current offence have a sexual motivation?",
                 "displayOrder": 12,
                 "mandatory": true,
+                "validation": "{\"mandatory\":{\"errorMessage\":\"Select yes or no\",\"errorSummary\":\"Select yes or no (current sexual offence)\"}}",
+                "readOnly": false,
+                "conditional": true,
+                "referenceDataTargets": [],
+                "answerSchemas": [
+                  {
+                    "answerSchemaUuid": "0d4682ab-7b24-4527-b0b3-b4d520e7c2d8",
+                    "answerSchemaCode": "yes",
+                    "value": "YES",
+                    "text": "Yes",
+                    "conditionals": [
+                      {
+                        "conditional": "86ee742c-4bfb-4e29-afca-04ad35a3abda",
+                        "displayInline": true
+                      }
+                    ]
+                  },
+                  {
+                    "answerSchemaUuid": "2a6011b2-4973-4249-99fd-9f84dbb2c88e",
+                    "answerSchemaCode": "no",
+                    "value": "NO",
+                    "text": "No"
+                  }
+                ]
+              },
+              {
+                "type": "question",
+                "questionId": "86ee742c-4bfb-4e29-afca-04ad35a3abda",
+                "questionCode": "61.1",
+                "answerType": "radio",
+                "questionText": "Does the current offence involve a victim who was a stranger?",
+                "displayOrder": 13,
+                "mandatory": true,
+                "validation": "{\"mandatory\":{\"errorMessage\":\"Select yes or no\",\"errorSummary\":\"Select yes or no (contact against a stranger victim)\"}}",
+                "readOnly": false,
+                "conditional": true,
+                "referenceDataTargets": [],
+                "answerSchemas": [
+                  {
+                    "answerSchemaUuid": "0d4682ab-7b24-4527-b0b3-b4d520e7c2d8",
+                    "answerSchemaCode": "yes",
+                    "value": "YES",
+                    "text": "Yes"
+                  },
+                  {
+                    "answerSchemaUuid": "2a6011b2-4973-4249-99fd-9f84dbb2c88e",
+                    "answerSchemaCode": "no",
+                    "value": "NO",
+                    "text": "No"
+                  }
+                ]
+              },
+              {
+                "type": "question",
+                "questionId": "a00223d0-1c20-43b5-8076-8a292ca25773",
+                "questionCode": "62.1",
+                "answerType": "date",
+                "questionText": "Date of most recent sanction involving a sexual or sexually motivated offence",
+                "helpText": "For example, 12 11 2007",
+                "displayOrder": 14,
+                "mandatory": true,
+                "validation": "{\"mandatory\":{\"errorMessage\":\"Enter the date of the most recent sanction involving a sexual or sexually motivated offence\",\"errorSummary\":\"Enter the date of the most recent sanction involving a sexual or sexually motivated offence\"}}",
+                "readOnly": false,
+                "conditional": true,
+                "referenceDataTargets": [],
+                "answerSchemas": []
+              },
+              {
+                "type": "question",
+                "questionId": "fc45b061-a4a6-44c3-937c-2949069e0926",
+                "questionCode": "63.1",
+                "answerType": "numeric",
+                "questionText": "Number of previous or current sanctions involving contact adult sexual or sexually motivated offences",
+                "displayOrder": 15,
+                "mandatory": true,
+                "validation": "{\"mandatory\":{\"errorMessage\":\"Enter the number of previous or current sanctions involving contact adult sexual or sexually motivated offences\",\"errorSummary\":\"Enter the number of previous or current sanctions involving contact adult sexual or sexually motivated offences\"}}",
+                "readOnly": false,
+                "conditional": true,
+                "referenceDataTargets": [],
+                "answerSchemas": []
+              },
+              {
+                "type": "question",
+                "questionId": "ed495c57-21f3-4388-87e6-57017a6999b1",
+                "questionCode": "64.1",
+                "answerType": "numeric",
+                "questionText": "Number of previous or current sanctions involving contact child sexual or sexually motivated offences",
+                "displayOrder": 16,
+                "mandatory": true,
+                "validation": "{\"mandatory\":{\"errorMessage\":\"Enter the number of previous or current sanctions involving contact child sexual or sexually offences\",\"errorSummary\":\"Enter the number of previous or current sanctions involving contact child sexual or sexually motivated offences\"}}",
+                "readOnly": false,
+                "conditional": true,
+                "referenceDataTargets": [],
+                "answerSchemas": []
+              },
+              {
+                "type": "question",
+                "questionId": "00a559e4-32d5-4ae7-aa21-247068a639ad",
+                "questionCode": "65.1",
+                "answerType": "numeric",
+                "questionText": "Number of previous or current sanctions involving indecent child image sexual or sexually motivated offences",
+                "displayOrder": 17,
+                "mandatory": true,
+                "validation": "{\"mandatory\":{\"errorMessage\":\"Enter the number of previous or current sanctions involving indecent child image sexual or sexually motivated offences\",\"errorSummary\":\"Enter the number of previous or current sanctions involving indecent child image sexual or sexually motivated offences\"}}",
+                "readOnly": false,
+                "conditional": true,
+                "referenceDataTargets": [],
+                "answerSchemas": []
+              },
+              {
+                "type": "question",
+                "questionId": "1b6c8f79-0fd9-45d4-ba50-309c3ccfdb2d",
+                "questionCode": "66.1",
+                "answerType": "numeric",
+                "questionText": "Number of previous or current sanctions involving other non-contact sexual or sexually motivated offences",
+                "displayOrder": 18,
+                "mandatory": true,
+                "validation": "{\"mandatory\":{\"errorMessage\":\"Enter the number of previous or current sanctions involving other non-contact sexual or sexually motivated offences\",\"errorSummary\":\"Number of previous or current sanctions involving other non-contact sexual or sexually motivated offences\"}}",
+                "readOnly": false,
+                "conditional": true,
+                "referenceDataTargets": [],
+                "answerSchemas": []
+              },
+              {
+                "type": "question",
+                "questionId": "5cd344d4-acf3-45a9-9493-5dda5aa9dfa8",
+                "questionCode": "60.1",
+                "answerType": "date",
+                "questionText": "Date of commencement of community sentence or earliest possible release from custody",
+                "helpText": "For example, 12 11 2007",
+                "displayOrder": 19,
+                "mandatory": true,
+                "validation": "{\"mandatory\":{\"errorMessage\":\"Enter a date\",\"errorSummary\":\"Enter a date\"}}",
+                "readOnly": false,
+                "conditional": false,
+                "referenceDataTargets": [],
+                "answerSchemas": []
+              }
+            ]
+          },
+          {
+            "type": "group",
+            "groupId": "6d3a4377-2177-429e-a7fa-6aa2444d14dd",
+            "groupCode": "rsr_needs",
+            "title": "Needs",
+            "displayOrder": 2,
+            "mandatory": true,
+            "contents": [
+              {
+                "type": "question",
+                "questionId": "420c2ffe-8f2c-49b3-a523-674af3197b9e",
+                "questionCode": "67.1",
+                "answerType": "radio",
+                "questionText": "Have you completed an interview with the individual?",
+                "displayOrder": 1,
+                "mandatory": true,
+                "validation": "{\"mandatory\":{\"errorMessage\":\"Select yes or no\",\"errorSummary\":\"Select yes or no (completed an interview with the individual)\"}}",
                 "readOnly": false,
                 "conditional": false,
                 "referenceDataTargets": [],
                 "answerSchemas": [
                   {
-                    "answerSchemaUuid": "7846b56e-5004-47db-a59d-a84c85d7b69a",
-                    "answerSchemaCode": "previous_conviction",
+                    "answerSchemaUuid": "0d4682ab-7b24-4527-b0b3-b4d520e7c2d8",
+                    "answerSchemaCode": "yes",
                     "value": "YES",
-                    "text": "Previous conviction"
+                    "text": "Yes",
+                    "conditionals": [
+                      {
+                        "conditional": "bd629547-eab9-46d5-910d-2416b431950f",
+                        "displayInline": false
+                      },
+                      {
+                        "conditional": "ed0e988a-38a4-4f9f-9691-08fb695cbed9",
+                        "displayInline": false
+                      },
+                      {
+                        "conditional": "3211a668-8878-4e88-8457-8250bfe65aea",
+                        "displayInline": false
+                      },
+                      {
+                        "conditional": "1970ba5e-91cb-4ad3-9f04-64d5b5b7157b",
+                        "displayInline": false
+                      },
+                      {
+                        "conditional": "f04dd882-0a0d-49f5-9736-91eeadbff9e7",
+                        "displayInline": false
+                      },
+                      {
+                        "conditional": "fb98f8b1-58ed-4aac-85b1-404f84270b95",
+                        "displayInline": false
+                      },
+                      {
+                        "conditional": "38b3a40a-df23-4ea1-872e-c04a8b03ee05",
+                        "displayInline": false
+                      },
+                      {
+                        "conditional": "f0416e89-3a71-46d1-8fa2-aebd886dcb34",
+                        "displayInline": false
+                      },
+                      {
+                        "conditional": "574618c3-27f4-4dd2-94bb-6de74126ff22",
+                        "displayInline": false
+                      },
+                      {
+                        "conditional": "5a90a38d-ee0a-4775-994c-addf3397b817",
+                        "displayInline": false
+                      },
+                      {
+                        "conditional": "d0619e6b-cc90-4031-90c6-ab15e06cc779",
+                        "displayInline": false
+                      },
+                      {
+                        "conditional": "91a60f48-89d4-4106-8f8a-fe797edca111",
+                        "displayInline": false
+                      }
+                    ]
+                  },
+                  {
+                    "answerSchemaUuid": "2a6011b2-4973-4249-99fd-9f84dbb2c88e",
+                    "answerSchemaCode": "no",
+                    "value": "NO",
+                    "text": "No"
+                  }
+                ]
+              },
+              {
+                "type": "question",
+                "questionId": "bd629547-eab9-46d5-910d-2416b431950f",
+                "questionCode": "69.1",
+                "answerType": "radio",
+                "questionText": "Did the offence involve carrying or use of a weapon?",
+                "displayOrder": 2,
+                "mandatory": true,
+                "validation": "{\"mandatory\":{\"errorMessage\":\"Select yes or no\",\"errorSummary\":\"Select yes or no (carrying or using weapon)\"}}",
+                "readOnly": false,
+                "conditional": true,
+                "referenceDataTargets": [],
+                "answerSchemas": [
+                  {
+                    "answerSchemaUuid": "0d4682ab-7b24-4527-b0b3-b4d520e7c2d8",
+                    "answerSchemaCode": "yes",
+                    "value": "YES",
+                    "text": "Yes",
+                    "conditionals": [
+                      {
+                        "conditional": "7f076a91-2702-438f-81ba-c15ebfab1b02",
+                        "displayInline": true
+                      }
+                    ]
+                  },
+                  {
+                    "answerSchemaUuid": "2a6011b2-4973-4249-99fd-9f84dbb2c88e",
+                    "answerSchemaCode": "no",
+                    "value": "NO",
+                    "text": "No"
+                  }
+                ]
+              },
+              {
+                "type": "question",
+                "questionId": "7f076a91-2702-438f-81ba-c15ebfab1b02",
+                "questionCode": "70.1",
+                "answerType": "freetext",
+                "questionText": "Specify which weapon",
+                "displayOrder": 3,
+                "mandatory": true,
+                "validation": "{\"mandatory\":{\"errorMessage\":\"Specify a weapon\",\"errorSummary\":\"Specify a weapon\"}}",
+                "readOnly": false,
+                "conditional": true,
+                "referenceDataTargets": [],
+                "answerSchemas": []
+              },
+              {
+                "type": "question",
+                "questionId": "ed0e988a-38a4-4f9f-9691-08fb695cbed9",
+                "questionCode": "75.1",
+                "answerType": "radio",
+                "questionText": "Is the individual living in suitable accommodation?",
+                "displayOrder": 4,
+                "mandatory": true,
+                "validation": "{\"mandatory\":{\"errorMessage\":\"Select the degree to which this is an issue\",\"errorSummary\":\"Select the degree to which this is an issue (suitability of accommodation)\"}}",
+                "readOnly": false,
+                "conditional": true,
+                "referenceDataTargets": [],
+                "answerSchemas": [
+                  {
+                    "answerSchemaUuid": "2dbde741-36ef-44b7-af79-fabdbf3e62c3",
+                    "answerSchemaCode": "no_problems",
+                    "value": "no problems",
+                    "text": "No problems"
+                  },
+                  {
+                    "answerSchemaUuid": "80cbb013-5633-44ca-b407-87fdde95652d",
+                    "answerSchemaCode": "some_problems",
+                    "value": "some problems",
+                    "text": "Some problems"
+                  },
+                  {
+                    "answerSchemaUuid": "2df8f5e2-7d04-41a4-a13f-f9df7479c775",
+                    "answerSchemaCode": "significant_problems",
+                    "value": "significant problems",
+                    "text": "Significant problems"
+                  }
+                ]
+              },
+              {
+                "type": "question",
+                "questionId": "3211a668-8878-4e88-8457-8250bfe65aea",
+                "questionCode": "80.1",
+                "answerType": "radio",
+                "questionText": "Is the person unemployed or will be unemployed upon release?",
+                "displayOrder": 5,
+                "mandatory": true,
+                "validation": "{\"mandatory\":{\"errorMessage\":\"Select an option\",\"errorSummary\":\"Enter yes or no (unemployed now or on release)\"}}",
+                "readOnly": false,
+                "conditional": true,
+                "referenceDataTargets": [],
+                "answerSchemas": [
+                  {
+                    "answerSchemaUuid": "d4c6ed05-73b4-4064-8255-7ccb96038988",
+                    "answerSchemaCode": "no",
+                    "value": "no",
+                    "text": "No"
+                  },
+                  {
+                    "answerSchemaUuid": "02c77c0c-f9fa-4c4c-a5dc-169aa33f5c86",
+                    "answerSchemaCode": "not_available_for_work",
+                    "value": "not available for work",
+                    "text": "Not available for work"
+                  },
+                  {
+                    "answerSchemaUuid": "f2619d17-2bda-40ce-9658-f6a7a371b3f2",
+                    "answerSchemaCode": "yes",
+                    "value": "yes",
+                    "text": "Yes"
+                  }
+                ]
+              },
+              {
+                "type": "question",
+                "questionId": "1970ba5e-91cb-4ad3-9f04-64d5b5b7157b",
+                "questionCode": "86.1",
+                "answerType": "radio",
+                "questionText": "What is the person's current relationship with their partner?",
+                "displayOrder": 6,
+                "mandatory": true,
+                "validation": "{\"mandatory\":{\"errorMessage\":\"Select the degree to which this is an issue\",\"errorSummary\":\"Select the degree to which this is an issue (current relationship with partner)\"}}",
+                "readOnly": false,
+                "conditional": true,
+                "referenceDataTargets": [],
+                "answerSchemas": [
+                  {
+                    "answerSchemaUuid": "2dbde741-36ef-44b7-af79-fabdbf3e62c3",
+                    "answerSchemaCode": "no_problems",
+                    "value": "no problems",
+                    "text": "No problems"
+                  },
+                  {
+                    "answerSchemaUuid": "80cbb013-5633-44ca-b407-87fdde95652d",
+                    "answerSchemaCode": "some_problems",
+                    "value": "some problems",
+                    "text": "Some problems"
+                  },
+                  {
+                    "answerSchemaUuid": "2df8f5e2-7d04-41a4-a13f-f9df7479c775",
+                    "answerSchemaCode": "significant_problems",
+                    "value": "significant problems",
+                    "text": "Significant problems"
+                  }
+                ]
+              },
+              {
+                "type": "question",
+                "questionId": "f04dd882-0a0d-49f5-9736-91eeadbff9e7",
+                "questionCode": "87.1",
+                "answerType": "radio",
+                "questionText": "Is there evidence that the individual is a perpetrator of domestic abuse?",
+                "displayOrder": 7,
+                "mandatory": true,
+                "validation": "{\"mandatory\":{\"errorMessage\":\"Select yes or no\",\"errorSummary\":\"Select yes or no (perpetrator of domestic  abuse?)\"}}",
+                "readOnly": false,
+                "conditional": true,
+                "referenceDataTargets": [],
+                "answerSchemas": [
+                  {
+                    "answerSchemaUuid": "0d4682ab-7b24-4527-b0b3-b4d520e7c2d8",
+                    "answerSchemaCode": "yes",
+                    "value": "YES",
+                    "text": "Yes",
+                    "conditionals": [
+                      {
+                        "conditional": "fb98f8b1-58ed-4aac-85b1-404f84270b95",
+                        "displayInline": true
+                      },
+                      {
+                        "conditional": "38b3a40a-df23-4ea1-872e-c04a8b03ee05",
+                        "displayInline": true
+                      }
+                    ]
+                  },
+                  {
+                    "answerSchemaUuid": "2a6011b2-4973-4249-99fd-9f84dbb2c88e",
+                    "answerSchemaCode": "no",
+                    "value": "NO",
+                    "text": "No"
+                  }
+                ]
+              },
+              {
+                "type": "question",
+                "questionId": "fb98f8b1-58ed-4aac-85b1-404f84270b95",
+                "questionCode": "88.1",
+                "answerType": "checkbox",
+                "questionText": "Victim",
+                "displayOrder": 8,
+                "mandatory": false,
+                "readOnly": false,
+                "conditional": true,
+                "referenceDataTargets": [],
+                "answerSchemas": [
+                  {
+                    "answerSchemaUuid": "4b6d2415-b152-4ba0-b030-1d203b5b31dc",
+                    "answerSchemaCode": "victim",
+                    "value": "victim",
+                    "text": "Victim"
+                  }
+                ]
+              },
+              {
+                "type": "question",
+                "questionId": "38b3a40a-df23-4ea1-872e-c04a8b03ee05",
+                "questionCode": "88.2",
+                "answerType": "checkbox",
+                "questionText": "Perpetrator",
+                "displayOrder": 9,
+                "mandatory": false,
+                "readOnly": false,
+                "conditional": true,
+                "referenceDataTargets": [],
+                "answerSchemas": [
+                  {
+                    "answerSchemaUuid": "9a52b4dd-5648-41d3-8d0d-171228d98474",
+                    "answerSchemaCode": "perpetrator",
+                    "value": "perpetrator",
+                    "text": "Perpetrator"
+                  }
+                ]
+              },
+              {
+                "type": "question",
+                "questionId": "f0416e89-3a71-46d1-8fa2-aebd886dcb34",
+                "questionCode": "90.1",
+                "answerType": "radio",
+                "questionText": "Is the person's current use of alcohol a problem?",
+                "displayOrder": 10,
+                "mandatory": true,
+                "validation": "{\"mandatory\":{\"errorMessage\":\"Select the degree to which this is an issue\",\"errorSummary\":\"Select the degree to which this is an issue (current use of alcohol)\"}}",
+                "readOnly": false,
+                "conditional": true,
+                "referenceDataTargets": [],
+                "answerSchemas": [
+                  {
+                    "answerSchemaUuid": "2dbde741-36ef-44b7-af79-fabdbf3e62c3",
+                    "answerSchemaCode": "no_problems",
+                    "value": "no problems",
+                    "text": "No problems"
+                  },
+                  {
+                    "answerSchemaUuid": "80cbb013-5633-44ca-b407-87fdde95652d",
+                    "answerSchemaCode": "some_problems",
+                    "value": "some problems",
+                    "text": "Some problems"
+                  },
+                  {
+                    "answerSchemaUuid": "2df8f5e2-7d04-41a4-a13f-f9df7479c775",
+                    "answerSchemaCode": "significant_problems",
+                    "value": "significant problems",
+                    "text": "Significant problems"
+                  }
+                ]
+              },
+              {
+                "type": "question",
+                "questionId": "574618c3-27f4-4dd2-94bb-6de74126ff22",
+                "questionCode": "92.1",
+                "answerType": "radio",
+                "questionText": "Is there evidence of binge drinking or excessive use of alcohol in the last 6 months?",
+                "displayOrder": 11,
+                "mandatory": true,
+                "validation": "{\"mandatory\":{\"errorMessage\":\"Select the degree to which this is an issue\",\"errorSummary\":\"Select the degree to which this is an issue (evidence of binge drinking or excessive alcohol use)\"}}",
+                "readOnly": false,
+                "conditional": true,
+                "referenceDataTargets": [],
+                "answerSchemas": [
+                  {
+                    "answerSchemaUuid": "2dbde741-36ef-44b7-af79-fabdbf3e62c3",
+                    "answerSchemaCode": "no_problems",
+                    "value": "no problems",
+                    "text": "No problems"
+                  },
+                  {
+                    "answerSchemaUuid": "80cbb013-5633-44ca-b407-87fdde95652d",
+                    "answerSchemaCode": "some_problems",
+                    "value": "some problems",
+                    "text": "Some problems"
+                  },
+                  {
+                    "answerSchemaUuid": "2df8f5e2-7d04-41a4-a13f-f9df7479c775",
+                    "answerSchemaCode": "significant_problems",
+                    "value": "significant problems",
+                    "text": "Significant problems"
+                  }
+                ]
+              },
+              {
+                "type": "question",
+                "questionId": "5a90a38d-ee0a-4775-994c-addf3397b817",
+                "questionCode": "113.1",
+                "answerType": "radio",
+                "questionText": "Is impulsivity a problem for the individual?",
+                "displayOrder": 12,
+                "mandatory": true,
+                "validation": "{\"mandatory\":{\"errorMessage\":\"Select the degree to which this is an issue\",\"errorSummary\":\"Select the degree to which this is an issue (impulsivity)\"}}",
+                "readOnly": false,
+                "conditional": true,
+                "referenceDataTargets": [],
+                "answerSchemas": [
+                  {
+                    "answerSchemaUuid": "2dbde741-36ef-44b7-af79-fabdbf3e62c3",
+                    "answerSchemaCode": "no_problems",
+                    "value": "no problems",
+                    "text": "No problems"
+                  },
+                  {
+                    "answerSchemaUuid": "80cbb013-5633-44ca-b407-87fdde95652d",
+                    "answerSchemaCode": "some_problems",
+                    "value": "some problems",
+                    "text": "Some problems"
+                  },
+                  {
+                    "answerSchemaUuid": "2df8f5e2-7d04-41a4-a13f-f9df7479c775",
+                    "answerSchemaCode": "significant_problems",
+                    "value": "significant problems",
+                    "text": "Significant problems"
+                  }
+                ]
+              },
+              {
+                "type": "question",
+                "questionId": "d0619e6b-cc90-4031-90c6-ab15e06cc779",
+                "questionCode": "115.1",
+                "answerType": "radio",
+                "questionText": "Is temper control a problem for the individual?",
+                "displayOrder": 13,
+                "mandatory": true,
+                "validation": "{\"mandatory\":{\"errorMessage\":\"Select the degree to which this is an issue\",\"errorSummary\":\"Select the degree to which this is an issue (temper control)\"}}",
+                "readOnly": false,
+                "conditional": true,
+                "referenceDataTargets": [],
+                "answerSchemas": [
+                  {
+                    "answerSchemaUuid": "2dbde741-36ef-44b7-af79-fabdbf3e62c3",
+                    "answerSchemaCode": "no_problems",
+                    "value": "no problems",
+                    "text": "No problems"
+                  },
+                  {
+                    "answerSchemaUuid": "80cbb013-5633-44ca-b407-87fdde95652d",
+                    "answerSchemaCode": "some_problems",
+                    "value": "some problems",
+                    "text": "Some problems"
+                  },
+                  {
+                    "answerSchemaUuid": "2df8f5e2-7d04-41a4-a13f-f9df7479c775",
+                    "answerSchemaCode": "significant_problems",
+                    "value": "significant problems",
+                    "text": "Significant problems"
+                  }
+                ]
+              },
+              {
+                "type": "checkboxGroup",
+                "checkboxGroupId": "91a60f48-89d4-4106-8f8a-fe797edca111",
+                "checkboxGroupCode": "rsr_previous_offences",
+                "title": "Previous offences",
+                "contents": [
+                  {
+                    "type": "question",
+                    "questionId": "0941c5b2-f42d-4120-ad79-44954674fe00",
+                    "questionCode": "130.1",
+                    "answerType": "checkbox",
+                    "questionText": "Murder/attempted murder/threat or conspiracy to murder/manslaughter",
+                    "displayOrder": 1,
+                    "mandatory": true,
+                    "readOnly": false,
+                    "conditional": false,
+                    "referenceDataTargets": [],
+                    "answerSchemas": [
+                      {
+                        "answerSchemaUuid": "59a0f4fe-4cca-426b-9402-0236dae24902",
+                        "answerSchemaCode": "yes",
+                        "value": "YES",
+                        "text": "Yes"
+                      },
+                      {
+                        "answerSchemaUuid": "c36d2ccd-c049-4640-806e-34b012f682d8",
+                        "answerSchemaCode": "no",
+                        "value": "NO",
+                        "text": "No"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "question",
+                    "questionId": "f988f76c-3d6c-4f45-aa29-7dc8d11198d7",
+                    "questionCode": "131.1",
+                    "answerType": "checkbox",
+                    "questionText": "Wounding/GBH (Sections 18/20 Offences Against the Person Act 1861)",
+                    "displayOrder": 2,
+                    "mandatory": true,
+                    "readOnly": false,
+                    "conditional": false,
+                    "referenceDataTargets": [],
+                    "answerSchemas": [
+                      {
+                        "answerSchemaUuid": "59a0f4fe-4cca-426b-9402-0236dae24902",
+                        "answerSchemaCode": "yes",
+                        "value": "YES",
+                        "text": "Yes"
+                      },
+                      {
+                        "answerSchemaUuid": "c36d2ccd-c049-4640-806e-34b012f682d8",
+                        "answerSchemaCode": "no",
+                        "value": "NO",
+                        "text": "No"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "question",
+                    "questionId": "ad81d270-4acc-472c-a79e-01d0a422ce80",
+                    "questionCode": "135.1",
+                    "answerType": "checkbox",
+                    "questionText": "Aggravated burglary",
+                    "displayOrder": 3,
+                    "mandatory": true,
+                    "readOnly": false,
+                    "conditional": false,
+                    "referenceDataTargets": [],
+                    "answerSchemas": [
+                      {
+                        "answerSchemaUuid": "59a0f4fe-4cca-426b-9402-0236dae24902",
+                        "answerSchemaCode": "yes",
+                        "value": "YES",
+                        "text": "Yes"
+                      },
+                      {
+                        "answerSchemaUuid": "c36d2ccd-c049-4640-806e-34b012f682d8",
+                        "answerSchemaCode": "no",
+                        "value": "NO",
+                        "text": "No"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "question",
+                    "questionId": "f8789074-1532-4b32-8995-780da18e273a",
+                    "questionCode": "136.1",
+                    "answerType": "checkbox",
+                    "questionText": "Arson",
+                    "displayOrder": 4,
+                    "mandatory": true,
+                    "readOnly": false,
+                    "conditional": false,
+                    "referenceDataTargets": [],
+                    "answerSchemas": [
+                      {
+                        "answerSchemaUuid": "59a0f4fe-4cca-426b-9402-0236dae24902",
+                        "answerSchemaCode": "yes",
+                        "value": "YES",
+                        "text": "Yes"
+                      },
+                      {
+                        "answerSchemaUuid": "c36d2ccd-c049-4640-806e-34b012f682d8",
+                        "answerSchemaCode": "no",
+                        "value": "NO",
+                        "text": "No"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "question",
+                    "questionId": "df5d635a-6765-42af-9007-6d6d333da5f2",
+                    "questionCode": "137.1",
+                    "answerType": "checkbox",
+                    "questionText": "Criminal damage with intent to endanger life",
+                    "displayOrder": 5,
+                    "mandatory": true,
+                    "readOnly": false,
+                    "conditional": false,
+                    "referenceDataTargets": [],
+                    "answerSchemas": [
+                      {
+                        "answerSchemaUuid": "59a0f4fe-4cca-426b-9402-0236dae24902",
+                        "answerSchemaCode": "yes",
+                        "value": "YES",
+                        "text": "Yes"
+                      },
+                      {
+                        "answerSchemaUuid": "c36d2ccd-c049-4640-806e-34b012f682d8",
+                        "answerSchemaCode": "no",
+                        "value": "NO",
+                        "text": "No"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "question",
+                    "questionId": "c2b221b4-ee1f-41c8-8fc7-9d49998fab35",
+                    "questionCode": "138.1",
+                    "answerType": "checkbox",
+                    "questionText": "Kidnapping/false imprisonment",
+                    "displayOrder": 6,
+                    "mandatory": true,
+                    "readOnly": false,
+                    "conditional": false,
+                    "referenceDataTargets": [],
+                    "answerSchemas": [
+                      {
+                        "answerSchemaUuid": "59a0f4fe-4cca-426b-9402-0236dae24902",
+                        "answerSchemaCode": "yes",
+                        "value": "YES",
+                        "text": "Yes"
+                      },
+                      {
+                        "answerSchemaUuid": "c36d2ccd-c049-4640-806e-34b012f682d8",
+                        "answerSchemaCode": "no",
+                        "value": "NO",
+                        "text": "No"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "question",
+                    "questionId": "e887bcea-91d1-4c50-a25e-4335fa1e6ae5",
+                    "questionCode": "139.1",
+                    "answerType": "checkbox",
+                    "questionText": "Possession of a firearm with intent to endanger life or resist arrest",
+                    "displayOrder": 7,
+                    "mandatory": true,
+                    "readOnly": false,
+                    "conditional": false,
+                    "referenceDataTargets": [],
+                    "answerSchemas": [
+                      {
+                        "answerSchemaUuid": "59a0f4fe-4cca-426b-9402-0236dae24902",
+                        "answerSchemaCode": "yes",
+                        "value": "YES",
+                        "text": "Yes"
+                      },
+                      {
+                        "answerSchemaUuid": "c36d2ccd-c049-4640-806e-34b012f682d8",
+                        "answerSchemaCode": "no",
+                        "value": "NO",
+                        "text": "No"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "question",
+                    "questionId": "9692659a-778a-436a-bf4e-fe1924638e37",
+                    "questionCode": "141.1",
+                    "answerType": "checkbox",
+                    "questionText": "Robbery",
+                    "displayOrder": 8,
+                    "mandatory": true,
+                    "readOnly": false,
+                    "conditional": false,
+                    "referenceDataTargets": [],
+                    "answerSchemas": [
+                      {
+                        "answerSchemaUuid": "59a0f4fe-4cca-426b-9402-0236dae24902",
+                        "answerSchemaCode": "yes",
+                        "value": "YES",
+                        "text": "Yes"
+                      },
+                      {
+                        "answerSchemaUuid": "c36d2ccd-c049-4640-806e-34b012f682d8",
+                        "answerSchemaCode": "no",
+                        "value": "NO",
+                        "text": "No"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "question",
+                    "questionId": "68e31f3a-5175-47e2-986b-d722ad78d893",
+                    "questionCode": "142.1",
+                    "answerType": "checkbox",
+                    "questionText": "Any other offence involving possession and/or use of weapons",
+                    "displayOrder": 9,
+                    "mandatory": true,
+                    "readOnly": false,
+                    "conditional": false,
+                    "referenceDataTargets": [],
+                    "answerSchemas": [
+                      {
+                        "answerSchemaUuid": "59a0f4fe-4cca-426b-9402-0236dae24902",
+                        "answerSchemaCode": "yes",
+                        "value": "YES",
+                        "text": "Yes"
+                      },
+                      {
+                        "answerSchemaUuid": "c36d2ccd-c049-4640-806e-34b012f682d8",
+                        "answerSchemaCode": "no",
+                        "value": "NO",
+                        "text": "No"
+                      }
+                    ]
                   }
                 ]
               }

--- a/wiremock/responses/updateEpisode.json
+++ b/wiremock/responses/updateEpisode.json
@@ -16,15 +16,15 @@
     {
       "type": "OSP/C",
       "scores": [
-        { "level": "MEDIUM", "score": 8.76, "isValid": true, "date": "2020-07-01T12:00:00" },
-        { "level": "MEDIUM", "score": 8.76, "isValid": true, "date": "2020-06-01T12:00:00" }
+        { "level": "MEDIUM", "isValid": true, "date": "2020-07-01T12:00:00" },
+        { "level": "MEDIUM", "isValid": true, "date": "2020-06-01T12:00:00" }
       ]
     },
     {
       "type": "OSP/I",
       "scores": [
-        { "level": "LOW", "score": 3.45, "isValid": true, "date": "2020-07-01T12:00:00" },
-        { "level": "LOW", "score": 3.45, "isValid": true, "date": "2020-06-01T12:00:00" }
+        { "level": "LOW", "isValid": true, "date": "2020-07-01T12:00:00" },
+        { "level": "LOW", "isValid": true, "date": "2020-06-01T12:00:00" }
       ]
     }
   ]

--- a/wiremock/responses/updateEpisode.json
+++ b/wiremock/responses/updateEpisode.json
@@ -1,0 +1,31 @@
+{
+  "episodeId": 1,
+  "episodeUuid": "22222222-2222-2222-2222-222222222222",
+  "assessmentUuid": "fb6b7c33-07fc-4c4c-a009-8d60f66952c4",
+  "reasonForChange": "new episode",
+  "created": "2019-11-14T08:11:53.177108",
+  "answers": {},
+  "predictors": [
+    {
+      "type": "RSR",
+      "scores": [
+        { "level": "HIGH", "score": 11.34, "isValid": true, "date": "2020-07-01T12:00:00" },
+        { "level": "HIGH", "score": 11.34, "isValid": true, "date": "2020-06-01T12:00:00" }
+      ]
+    },
+    {
+      "type": "OSP/C",
+      "scores": [
+        { "level": "MEDIUM", "score": 8.76, "isValid": true, "date": "2020-07-01T12:00:00" },
+        { "level": "MEDIUM", "score": 8.76, "isValid": true, "date": "2020-06-01T12:00:00" }
+      ]
+    },
+    {
+      "type": "OSP/I",
+      "scores": [
+        { "level": "LOW", "score": 3.45, "isValid": true, "date": "2020-07-01T12:00:00" },
+        { "level": "LOW", "score": 3.45, "isValid": true, "date": "2020-06-01T12:00:00" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Background

This PR adds the predictor scores page to the RSR assessment, predictors are calculated when submitting the `Needs` section of the `RSR` and cached for the following pages.

## Intent

- Create predictor scores page template
- Create predictor score components
- Create predictor confirmation page

## Screenshots

![predictors](https://user-images.githubusercontent.com/20080441/128472402-7aab4aeb-120c-4358-a752-cc834635f6be.gif)

## Considerations

The mocked responses assume the predictor scores to be returned from the assessments API when updating an episode with the following shape

```json
  "episodeId": 1,
  "episodeUuid": "22222222-2222-2222-2222-222222222222",
  "assessmentUuid": "fb6b7c33-07fc-4c4c-a009-8d60f66952c4",
  "reasonForChange": "new episode",
  "created": "2019-11-14T08:11:53.177108",
  "answers": {},
  "predictors": [
    {
      "type": "RSR",
      "scores": [
        { "level": "HIGH", "score": 11.34, "isValid": true, "date": "2020-07-01T12:00:00" },
        { "level": "HIGH", "score": 11.34, "isValid": true, "date": "2020-06-01T12:00:00" }
      ]
    },
    {
      "type": "OSP/C",
      "scores": [
        { "level": "MEDIUM", "isValid": true, "date": "2020-07-01T12:00:00" },
        { "level": "MEDIUM", "isValid": true, "date": "2020-06-01T12:00:00" }
      ]
    },
    {
      "type": "OSP/I",
      "scores": [
        { "level": "LOW", "isValid": true, "date": "2020-07-01T12:00:00" },
        { "level": "LOW", "isValid": true, "date": "2020-06-01T12:00:00" }
      ]
    }
  ]
```

The predictors are cached and used later for displaying on the predictors page, we could potentially decouple the predictors calculation from the `update episode` event and avoid caching.

A few other things:

 - Offender details requires the `assessmentUuid`, however this is not needed for the predictors page - could we potentially get offender details using an `episodeUuid` ? this would prevent us having to include the `assessmentUuid` as another URL param
 - As we don't have conditional pages, the predictor calculation is tied to the `Needs` page specifically. This limitation will likely be addressed as part of the ref-data rework



