### PR TITLE
Add missing closing tag to RSR help section

### DIFF
--- a/common/templates/components/help/template.njk
+++ b/common/templates/components/help/template.njk
@@ -495,7 +495,7 @@
           <li>shows the same pattern of frustration and over-reaction as those who have ‘significant problems’ but with less frequency</li>
           <li>has infrequent bouts of uncontrolled anger</li>
           <li>has only one documented episode of loss of control (the current offence) and the interview fails to reveal any others</li>
-        <ul>
+        </ul>
         <p class='govuk-body'><strong>Significant problems.</strong></p>
         <p class='govuk-body'>The individual:</p>
         <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
This should fix the incorrect indentation as seen here 
![image (1)](https://user-images.githubusercontent.com/20080441/130057935-1a802e90-ef00-480c-a7cd-c5e3655e2024.png)
