### PR TITLE
Fix integration when handling answers and table data

### DIFF
--- a/app/editRow/get.controller.js
+++ b/app/editRow/get.controller.js
@@ -26,21 +26,14 @@ const editTableRow = async (
     }
     res.locals.assessmentUuid = assessmentId
 
-    const { answers } = await grabAnswers(assessmentId, 'current', user?.token, user?.id)
+    const { tables = {} } = await grabAnswers(assessmentId, 'current', user?.token, user?.id)
 
     // update answers to just appropriate ones for this table row
     // go through questions
 
     // if this question is in answers, change answer to just the one for this row
-    thisTable.contents.forEach(question => {
-      if (answers[question.questionCode] && answers[question.questionCode].length > tableRow) {
-        if (Array.isArray(answers[question.questionCode][tableRow])) {
-          answers[question.questionCode] = answers[question.questionCode][tableRow]
-        } else {
-          answers[question.questionCode] = [answers[question.questionCode][tableRow]]
-        }
-      }
-    })
+    const tableEntries = tables[tableName] || []
+    const answers = tableEntries.length > tableRow ? tableEntries[tableRow] : {}
 
     let questions = annotateWithAnswers(thisTable.contents, answers, body)
     questions = compileInlineConditionalQuestions(questions, errors)

--- a/app/editRow/get.controller.test.js
+++ b/app/editRow/get.controller.test.js
@@ -56,6 +56,7 @@ describe('display table group and answers', () => {
   it('should render the page with the correct structure', async () => {
     getAnswers.mockReturnValueOnce({
       answers: {},
+      tables: {},
     })
     await editTableRow(req, res)
     expect(res.render).toHaveBeenCalledWith(`${__dirname}/index`, expectedForThisTest)

--- a/app/questionGroup/get.controller.js
+++ b/app/questionGroup/get.controller.js
@@ -14,13 +14,13 @@ const displayQuestionGroup = async (
     const { questionGroup } = res.locals
     const subIndex = Number.parseInt(subgroup, 10)
 
-    const { answers, episodeUuid } = await grabAnswers(assessmentId, 'current', user?.token, user?.id)
+    const { answers = {}, tables = {}, episodeUuid } = await grabAnswers(assessmentId, 'current', user?.token, user?.id)
 
     res.locals.assessmentUuid = assessmentId
     res.locals.episodeUuid = episodeUuid
 
     let questions = flattenCheckboxGroups(questionGroup.contents)
-    questions = annotateWithAnswers(questions, answers, body)
+    questions = annotateWithAnswers(questions, answers, body, tables)
     questions = compileInlineConditionalQuestions(questions, errors)
 
     return res.render(`${__dirname}/index`, {

--- a/common/data/hmppsAssessmentApi.js
+++ b/common/data/hmppsAssessmentApi.js
@@ -60,18 +60,18 @@ const postAnswers = (assessmentId, episodeId, answers, authorisationToken, userI
 }
 
 const postTableRow = (assessmentId, episodeId, tableName, answers, authorisationToken, userId) => {
-  const path = `${url}/assessments/${assessmentId}/episodes/${episodeId}/${tableName}`
+  const path = `${url}/assessments/${assessmentId}/episodes/${episodeId}/table/${tableName}`
   return postData(path, authorisationToken, userId, answers)
 }
 
 const deleteTableRow = (assessmentId, episodeId, tableName, tableRow, authorisationToken, userId) => {
-  const path = `${url}/assessments/${assessmentId}/episodes/${episodeId}/${tableName}/${tableRow}`
+  const path = `${url}/assessments/${assessmentId}/episodes/${episodeId}/table/${tableName}/${tableRow}`
   return deleteData(path, authorisationToken, userId)
 }
 
 const updateTableRow = (assessmentId, episodeId, tableName, tableRow, answers, authorisationToken, userId) => {
-  const path = `${url}/assessments/${assessmentId}/episodes/${episodeId}/${tableName}/${tableRow}`
-  return postData(path, authorisationToken, userId, answers)
+  const path = `${url}/assessments/${assessmentId}/episodes/${episodeId}/table/${tableName}/${tableRow}`
+  return putData(path, authorisationToken, userId, answers)
 }
 
 const getDraftPredictorScore = (episodeUuid, authorisationToken, userId) => {
@@ -104,6 +104,12 @@ const postData = (path, authorisationToken, userId, data) => {
   logger.info(`Calling hmppsAssessments API with POST: ${path}`)
 
   return action(superagent.post(path).send(data), authorisationToken, userId)
+}
+
+const putData = (path, authorisationToken, userId, data) => {
+  logger.info(`Calling hmppsAssessments API with PUT: ${path}`)
+
+  return action(superagent.put(path).send(data), authorisationToken, userId)
 }
 
 const deleteData = (path, authorisationToken, userId) => {

--- a/wiremock/assessmentApi.js
+++ b/wiremock/assessmentApi.js
@@ -231,11 +231,39 @@ const stubQuestionsList = () => {
     },
   })
 }
-const stubDeleteTableRow = () => {
+const stubAddTableRow = () => {
+  stubFor({
+    request: {
+      method: 'POST',
+      urlPattern: `/assessments/.+?/episodes/.+?/table/.+?`,
+    },
+    response: {
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      status: 200,
+    },
+  })
+}
+const stubUpdateTableRow = () => {
+  stubFor({
+    request: {
+      method: 'PUT',
+      urlPattern: `/assessments/.+?/episodes/.+?/table/.+?`,
+    },
+    response: {
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      status: 200,
+    },
+  })
+}
+const stubRemoveTableRow = () => {
   stubFor({
     request: {
       method: 'DELETE',
-      urlPattern: `/assessments/.+?/episodes/.+?/.+?`,
+      urlPattern: `/assessments/.+?/episodes/.+?/table/.+?`,
     },
     response: {
       headers: {
@@ -335,8 +363,10 @@ const stubEpisodes = async () => {
 const stubSupervision = async () => {
   await stubAssessmentSupervision()
 }
-const stubRemoveTableRow = async () => {
-  await stubDeleteTableRow()
+const stubTableActions = async () => {
+  await stubAddTableRow()
+  await stubUpdateTableRow()
+  await stubRemoveTableRow()
 }
 
 const stubErrors = () => {
@@ -372,7 +402,7 @@ module.exports = {
   stubAssessmentComplete,
   stubGetAssessments,
   stubGetQuestionGroup,
-  stubRemoveTableRow,
+  stubTableActions,
   stubErrors,
   stubAssessmentQuestions,
   stubPredictors,

--- a/wiremock/responses/assessmentEpisodes.json
+++ b/wiremock/responses/assessmentEpisodes.json
@@ -4,6 +4,9 @@
   "assessmentUuid": "fb6b7c33-07fc-4c4c-a009-8d60f66952c4",
   "reasonForChange": "new episode",
   "created": "2019-11-14T08:11:53.177108",
+  "tables": {
+    "children_at_risk_of_serious_harm": {}
+  },
   "answers": {
     "33923c1e-e3ba-4c02-ba42-3b8d828f9e18": ["Hart"],
     "81cbd5f5-f8ec-430e-b18a-c48fdf660216": ["None"],

--- a/wiremock/stub.js
+++ b/wiremock/stub.js
@@ -10,9 +10,9 @@ const {
   stubAssessmentComplete,
   stubGetAssessments,
   stubGetQuestionGroup,
-  stubRemoveTableRow,
   stubAssessmentTypeSummaries,
   stubAssessmentQuestions,
+  stubTableActions,
 } = require('./assessmentApi')
 const { stubGetAssessmentFromDelius, stubPostAssessmentFromDelius } = require('./assessmentFromDelius')
 const { stubStart } = require('./start')
@@ -52,7 +52,7 @@ async function stub() {
   await stubGetQuestionGroup()
   await stubReferenceData()
   await stubOasysUser()
-  await stubRemoveTableRow()
+  await stubTableActions()
   await stubOffenderDetails()
   await stubGetUserProfile()
   await stubAssessmentQuestions()


### PR DESCRIPTION
## Background

This PR fixes the integration with the assessments API following the Tables/Answers refactor

## Intent
- Update endpoints for tables
- Update WireMock stubs
- Update `annotateWithAnswers` usage to use Table entries

## Notes

Changes in this PR are related to the ones in the PR for the Assessment API
- https://github.com/ministryofjustice/hmpps-assessments-api/pull/280