### PR TITLE
Fix call to getAnsers in RSR

### DIFF
--- a/app/rsr/controllers/saveAndContinue.js
+++ b/app/rsr/controllers/saveAndContinue.js
@@ -287,8 +287,8 @@ class SaveAndContinue extends Controller {
     res.locals.errorSummary = errorSummary
 
     const previousAnswers = await getAnswers(
-      req.assessment?.uuid,
-      req.assessment?.episodeUuid,
+      req.session.assessment?.uuid,
+      req.session.assessment?.episodeUuid,
       req.user?.token,
       req.user?.id,
     )
@@ -370,7 +370,7 @@ class SaveAndContinue extends Controller {
     try {
       const [ok, response] = await postAnswers(
         req.session?.assessment?.uuid,
-        'current',
+        req.session?.assessment?.episodeUuid,
         { answers },
         user?.token,
         user?.id,

--- a/app/rsr/controllers/saveAndContinue.test.js
+++ b/app/rsr/controllers/saveAndContinue.test.js
@@ -13,6 +13,7 @@ jest.mock('../fields')
 
 let req
 const user = { token: 'mytoken', id: '1' }
+const assessmentUuid = '22222222-2222-2222-2222-222222222221'
 const episodeUuid = '22222222-2222-2222-2222-222222222222'
 
 const controller = new SaveAndContinueController({
@@ -51,7 +52,8 @@ describe('SaveAndContinueController', () => {
       },
       session: {
         assessment: {
-          uuid: 'test-assessment-id',
+          uuid: assessmentUuid,
+          episodeUuid,
           subject: { dob: '1980-01-01' },
         },
       },
@@ -266,6 +268,13 @@ describe('SaveAndContinueController', () => {
       })
 
       await controller.locals(req, res, () => {})
+
+      expect(getAnswers).toHaveBeenCalledWith(
+        req.session.assessment.uuid,
+        req.session.assessment.episodeUuid,
+        req.user.token,
+        req.user.id,
+      )
 
       expect(res.locals.questions).toEqual({
         first_question: {
@@ -482,8 +491,8 @@ describe('SaveAndContinueController', () => {
 
       expect(req.sessionModel.get).toHaveBeenCalledWith('answers')
       expect(postAnswers).toHaveBeenCalledWith(
-        'test-assessment-id',
-        'current',
+        assessmentUuid,
+        episodeUuid,
         {
           answers: {
             some_field: ['foo'],
@@ -512,13 +521,7 @@ describe('SaveAndContinueController', () => {
       const theError = 'Something went wrong'
 
       expect(req.sessionModel.get).toHaveBeenCalledWith('answers')
-      expect(postAnswers).toHaveBeenCalledWith(
-        req.session.assessment.uuid,
-        'current',
-        { answers: {} },
-        user.token,
-        user.id,
-      )
+      expect(postAnswers).toHaveBeenCalledWith(assessmentUuid, episodeUuid, { answers: {} }, user.token, user.id)
       expect(res.render).toHaveBeenCalledWith('app/error', { subHeading: theError })
     })
 


### PR DESCRIPTION
Fixes an issue with the call to `getAnswers` in the RSR workflow. I've also updated the `postAnswers` call to use the `episodeUuid` as opposed to `current`