### PR TITLE
Create confirmation controller

### DIFF
--- a/app/upw/controllers/confirmation.js
+++ b/app/upw/controllers/confirmation.js
@@ -1,0 +1,59 @@
+/* eslint-disable class-methods-use-this */
+const nunjucks = require('nunjucks')
+const SaveAndContinue = require('./saveAndContinue')
+const logger = require('../../../common/logging/logger')
+const { uploadPdfDocumentToDelius } = require('../../../common/data/hmppsAssessmentApi')
+const { convertHtmlToPdf } = require('../../../common/data/pdf')
+
+const createFileNameFrom = (...parts) => {
+  return parts
+    .filter(s => s !== '')
+    .join('-')
+    .toLowerCase()
+}
+
+class Confirmation extends SaveAndContinue {
+  async render(req, res, next) {
+    try {
+      const renderedHtml = nunjucks.render('app/upw/templates/pdf-preview-and-declaration/pdf.njk', {
+        ...res.locals,
+        css_path: 'application.min.css',
+      })
+
+      const firstName = res.locals.rawAnswers.first_name || ''
+      const familyName = res.locals.rawAnswers.family_name || ''
+      const crn = res.locals.rawAnswers.crn || ''
+
+      const fileName = createFileNameFrom(firstName, familyName, crn)
+
+      const pdfConvertResponse = await convertHtmlToPdf(renderedHtml)
+
+      if (!pdfConvertResponse.ok) {
+        logger.error(`Failed to convert template to PDF, status=${pdfConvertResponse.status}`)
+        throw new Error('Failed to convert template to PDF')
+      }
+
+      const deliusUploadResponse = await uploadPdfDocumentToDelius(
+        req.session?.assessment?.uuid,
+        req.session?.assessment?.episodeUuid,
+        { document: pdfConvertResponse.body, fileName },
+        req.user,
+      )
+
+      if (!deliusUploadResponse.ok) {
+        if (deliusUploadResponse.status >= 500) {
+          return res.redirect('/UPW/delius-error')
+        }
+
+        logger.error(`Failed to upload the PDF, status=${deliusUploadResponse.status}`)
+        throw new Error('Failed to upload the PDF')
+      }
+
+      return super.render(req, res, next)
+    } catch (e) {
+      return next(e)
+    }
+  }
+}
+
+module.exports = Confirmation

--- a/app/upw/controllers/confirmation.test.js
+++ b/app/upw/controllers/confirmation.test.js
@@ -1,0 +1,171 @@
+const nock = require('nock')
+const { Controller } = require('hmpo-form-wizard')
+const nunjucks = require('nunjucks')
+
+const ConfirmationController = require('./confirmation')
+
+jest.mock('nunjucks')
+jest.mock('../../../common/utils/util', () => ({
+  getCorrelationId: jest.fn(() => 'mocked-correlation-id'),
+}))
+
+const createTestFile = () => Buffer.from('Test Buffer')
+
+describe('ConfirmationController', () => {
+  describe('Render', () => {
+    const superMethod = jest.spyOn(Controller.prototype, 'render')
+    const controller = new ConfirmationController({
+      route: 'test-route',
+    })
+
+    let req
+    const user = { token: 'mytoken', id: '1' }
+    const assessmentUuid = '22222222-2222-2222-2222-222222222221'
+    const episodeUuid = '22222222-2222-2222-2222-222222222222'
+
+    const res = {
+      redirect: jest.fn(),
+      render: jest.fn(),
+      send: jest.fn(),
+      set: jest.fn(),
+      locals: {
+        'csrf-token': 'CSRF_TOKEN',
+        rawAnswers: {
+          first_name: 'Robert',
+          last_name: 'Robertson',
+          crn: 'X123456',
+        },
+      },
+    }
+
+    const next = jest.fn()
+
+    beforeEach(() => {
+      req = {
+        user,
+        body: {},
+        sessionModel: {
+          set: jest.fn(),
+          get: jest.fn(),
+        },
+        session: {
+          assessment: {
+            uuid: assessmentUuid,
+            episodeUuid,
+            subject: { dob: '1980-01-01' },
+          },
+        },
+        form: {
+          options: {
+            allFields: {},
+            fields: {},
+            journeyName: 'UPW',
+          },
+          values: {},
+        },
+      }
+
+      res.render.mockReset()
+      res.send.mockReset()
+      res.set.mockReset()
+      req.sessionModel.get.mockReset()
+      req.sessionModel.set.mockReset()
+      req.form.options.fields = {}
+      req.form.options.allFields = {}
+      next.mockReset()
+      nunjucks.render.mockReturnValue('RENDERED_TEMPLATE')
+    })
+
+    it('calls the PDF convert and passes the response to the backend API', async () => {
+      const file = createTestFile()
+
+      nock(/localhost/gi)
+        .post('/forms/chromium/convert/html')
+        .reply(200, file)
+
+      nock(/localhost/gi)
+        .post(`/assessments/${assessmentUuid}/episode/${episodeUuid}/document`)
+        .reply(200)
+
+      await controller.render(req, res, next)
+
+      expect(superMethod).toHaveBeenCalled()
+    })
+
+    it('passes an error to the error handler when PDF conversion fails', async () => {
+      const file = createTestFile()
+
+      nock(/localhost/gi)
+        .post('/forms/chromium/convert/html')
+        .reply(500)
+
+      await controller.render(req, res, next)
+
+      expect(next).toHaveBeenCalledWith(new Error('Failed to convert template to PDF'))
+    })
+
+    it('redirects to the "Delius is down" page when uploading the PDF returns a 500', async () => {
+      const file = createTestFile()
+
+      nock(/localhost/gi)
+        .post('/forms/chromium/convert/html')
+        .reply(200, file)
+
+      nock(/localhost/gi)
+        .post(`/assessments/${assessmentUuid}/episode/${episodeUuid}/document`)
+        .reply(500)
+
+      await controller.render(req, res, next)
+
+      expect(res.redirect).toHaveBeenCalledWith('/UPW/delius-error')
+    })
+
+    it('redirects to the "Delius is down" page when uploading the PDF returns a 502', async () => {
+      const file = createTestFile()
+
+      nock(/localhost/gi)
+        .post('/forms/chromium/convert/html')
+        .reply(200, file)
+
+      nock(/localhost/gi)
+        .post(`/assessments/${assessmentUuid}/episode/${episodeUuid}/document`)
+        .reply(502)
+
+      await controller.render(req, res, next)
+
+      expect(res.redirect).toHaveBeenCalledWith('/UPW/delius-error')
+    })
+
+    it('redirects to the "Delius is down" page when uploading the PDF returns a 503', async () => {
+      const file = createTestFile()
+
+      nock(/localhost/gi)
+        .post('/forms/chromium/convert/html')
+        .reply(200, file)
+
+      nock(/localhost/gi)
+        .post(`/assessments/${assessmentUuid}/episode/${episodeUuid}/document`)
+        .reply(503)
+
+      await controller.render(req, res, next)
+
+      expect(res.redirect).toHaveBeenCalledWith('/UPW/delius-error')
+    })
+
+    it('passes an error to the error handler when uploading the PDF returns a 400', async () => {
+      const file = createTestFile()
+
+      nock(/localhost/gi)
+        .post('/forms/chromium/convert/html')
+        .reply(200, file)
+
+      nock(/localhost/gi)
+        .post(`/assessments/${assessmentUuid}/episode/${episodeUuid}/document`)
+        .reply(400)
+
+      await controller.render(req, res, next)
+
+      expect(next).toHaveBeenCalledWith(new Error('Failed to upload the PDF'))
+    })
+  })
+})

--- a/app/upw/controllers/confirmation.test.js
+++ b/app/upw/controllers/confirmation.test.js
@@ -93,8 +93,6 @@ describe('ConfirmationController', () => {
     })
 
     it('passes an error to the error handler when PDF conversion fails', async () => {
-      const file = createTestFile()
-
       nock(/localhost/gi)
         .post('/forms/chromium/convert/html')
         .reply(500)

--- a/app/upw/controllers/confirmation.test.js
+++ b/app/upw/controllers/confirmation.test.js
@@ -8,6 +8,16 @@ jest.mock('nunjucks')
 jest.mock('../../../common/utils/util', () => ({
   getCorrelationId: jest.fn(() => 'mocked-correlation-id'),
 }))
+jest.mock('../../../common/data/userDetailsCache', () => ({
+  getCachedUserDetails: jest.fn(() => ({
+    isActive: true,
+    oasysUserCode: 'SUPPORT1',
+    username: 'Ray Arnold',
+    email: 'foo@bar.baz',
+    areaCode: 'HFS',
+    areaName: 'Hertfordshire',
+  })),
+}))
 
 const createTestFile = () => Buffer.from('Test Buffer')
 

--- a/app/upw/steps.js
+++ b/app/upw/steps.js
@@ -3,6 +3,7 @@ const TaskList = require('./controllers/taskList')
 const SaveAndContinue = require('./controllers/saveAndContinue')
 const ConvertPdf = require('./controllers/convertPdf')
 const Declaration = require('./controllers/declaration')
+const Confirmation = require('./controllers/confirmation')
 
 module.exports = {
   '/start': {
@@ -314,8 +315,14 @@ module.exports = {
   },
   '/confirmation': {
     pageTitle: 'Confirmation',
+    controller: Confirmation,
     noPost: true,
     template: `${__dirname}/templates/confirmation.njk`,
+  },
+  '/delius-error': {
+    pageTitle: 'Something went wrong',
+    noPost: true,
+    template: `${__dirname}/templates/delius-error.njk`,
   },
   '/assessment-saved': {
     pageTitle: 'Your assessment has been saved',

--- a/app/upw/steps.js
+++ b/app/upw/steps.js
@@ -320,7 +320,7 @@ module.exports = {
     template: `${__dirname}/templates/confirmation.njk`,
   },
   '/delius-error': {
-    pageTitle: 'Something went wrong',
+    pageTitle: 'There is a problem with the service',
     noPost: true,
     template: `${__dirname}/templates/delius-error.njk`,
   },

--- a/app/upw/templates/delius-error.njk
+++ b/app/upw/templates/delius-error.njk
@@ -18,7 +18,21 @@
     <div class="govuk-grid-column-three-quarters">
         <h1 class="govuk-heading-xl landing-page__heading">{{ options.journeyPageTitle }}</h1>
 
-        <p class="govuk-hint hint__large">{{ pageDescription }}</p>
+        <p class="govuk-body govuk-!-font-size-24">
+            The assessment cannot be sent to Delius at the moment because of connection problems. You can <a href="/UPW/pdf-download" class="govuk-link">download the PDF</a> and then manually send it to Delius when the connection is restored. Upload the PDF to the Delius CP/UPW Assessment contact, using its filename to identify it. 
+        </p>
+
+        <p class="govuk-body">
+            Remember to manually enter the (EASU) "CP/UPW Assessment" contact entry to confirm that the UPW has been completed within 15 Business days of sentence.
+        </p>
+
+        <p class="govuk-body">
+            After you download the PDF you can close this window.
+        </p>
+
+        <div class="govuk-button-group">
+            <a class="govuk-button" href="/UPW/pdf-download" download>Download the PDF</a>            
+        </div>
     </div>
 </div>
 {% endblock %}

--- a/app/upw/templates/delius-error.njk
+++ b/app/upw/templates/delius-error.njk
@@ -1,0 +1,24 @@
+{% extends "common/templates/layout.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "common/templates/components/question/macro.njk" import renderQuestion %}
+
+{% set hideBackLink = true %}
+
+{% block pageTitle %}
+{{ pageTitle }}
+{% endblock %}
+
+{% block header %}
+    {% include "common/templates/partials/header.njk" %}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters">
+        <h1 class="govuk-heading-xl landing-page__heading">{{ options.journeyPageTitle }}</h1>
+
+        <p class="govuk-hint hint__large">{{ pageDescription }}</p>
+    </div>
+</div>
+{% endblock %}

--- a/common/data/hmppsAssessmentApi.js
+++ b/common/data/hmppsAssessmentApi.js
@@ -121,10 +121,14 @@ const uploadPdfDocumentToDelius = async (assessmentUuid, episodeUuid, pdf, user)
     throw new Error('No authorisation token found when calling hmppsAssessments API')
   }
 
+  const endpoint = `/assessments/${assessmentUuid}/episode/${episodeUuid}/document`
+
+  logger.info(`Calling hmppsAssessments API with POST: ${endpoint}`)
+
   const userDetails = await getCachedUserDetails(user.id)
   try {
     return await superagent
-      .post(`${url}/assessments/${assessmentUuid}/episode/${episodeUuid}/document`)
+      .post(url + endpoint)
       .auth(user.token, { type: 'bearer' })
       .set('x-correlation-id', getCorrelationId())
       .set('x-user-area', userDetails?.areaCode || '')

--- a/common/data/hmppsAssessmentApi.js
+++ b/common/data/hmppsAssessmentApi.js
@@ -116,6 +116,27 @@ const getFilteredReferenceData = (assessmentId, episodeId, questionCode, parentL
   return postData(path, authorisationToken, userId, requestBody)
 }
 
+const uploadPdfDocumentToDelius = async (assessmentUuid, episodeUuid, pdf, user) => {
+  if (user.token === undefined) {
+    throw new Error('No authorisation token found when calling hmppsAssessments API')
+  }
+
+  const userDetails = await getCachedUserDetails(user.id)
+  try {
+    return await superagent
+      .post(`${url}/assessments/${assessmentUuid}/episode/${episodeUuid}/document`)
+      .auth(user.token, { type: 'bearer' })
+      .set('x-correlation-id', getCorrelationId())
+      .set('x-user-area', userDetails?.areaCode || '')
+      .accept('application/json')
+      .attach('fileData', pdf.document, pdf.fieldName)
+      .then(({ ok, body, status }) => ({ ok, response: body, status }))
+  } catch (e) {
+    const { response, status } = e
+    return { ok: false, response, status }
+  }
+}
+
 const getData = (path, authorisationToken, userId) => {
   logger.info(`Calling hmppsAssessments API with GET: ${path}`)
 
@@ -202,4 +223,5 @@ module.exports = {
   getCurrentEpisode,
   getRegistrationsForCrn,
   getRoshRiskSummaryForCrn,
+  uploadPdfDocumentToDelius,
 }

--- a/common/data/pdf.js
+++ b/common/data/pdf.js
@@ -1,0 +1,27 @@
+const superagent = require('superagent')
+const fs = require('fs')
+
+const {
+  apis: {
+    pdfConverter: { url },
+  },
+} = require('../config')
+
+const convertHtmlToPdf = async renderedHtml => {
+  try {
+    return await superagent
+      .post(url)
+      .accept('application/json')
+      .attach('files', Buffer.from(renderedHtml), 'index.html')
+      .attach('files', fs.readFileSync('public/stylesheets/application.min.css'), 'application.min.css')
+      .responseType('blob')
+      .then(({ ok, body, status }) => ({ ok, response: body, status }))
+  } catch (e) {
+    const { response, status } = e
+    return { ok: false, response, status }
+  }
+}
+
+module.exports = {
+  convertHtmlToPdf,
+}

--- a/integration-tests/plugins/index.js
+++ b/integration-tests/plugins/index.js
@@ -16,6 +16,7 @@ const {
   stubPredictors,
   stubRegistrations,
   stubRoshRiskSummary,
+  stubDocumentUpload,
 } = require('../../wiremock/assessmentApi')
 const { stubReferenceData } = require('../../wiremock/referenceData')
 const { stubAuth, getLoginUrl } = require('../../wiremock/auth')
@@ -49,6 +50,7 @@ module.exports = on => {
         stubPredictors(),
         stubRegistrations(),
         stubRoshRiskSummary(),
+        stubDocumentUpload(),
       ]),
     stubGetUserProfileWithSingleArea: () => Promise.all([stubGetUserProfileWithSingleArea()]),
     stubGetUserProfileWithMultipleAreas: () => Promise.all([stubGetUserProfile()]),

--- a/wiremock/assessmentApi.js
+++ b/wiremock/assessmentApi.js
@@ -360,7 +360,7 @@ const stubRoshRiskSummary = () => {
 const stubDocumentUpload = () => {
   stubFor({
     request: {
-      method: 'GET',
+      method: 'POST',
       urlPattern: `/assessments/.+?/episode/.+?/document`,
     },
     response: {

--- a/wiremock/assessmentApi.js
+++ b/wiremock/assessmentApi.js
@@ -357,6 +357,22 @@ const stubRoshRiskSummary = () => {
   })
 }
 
+const stubDocumentUpload = () => {
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: `/assessments/.+?/episode/.+?/document`,
+    },
+    response: {
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      status: 200,
+      jsonBody: {},
+    },
+  })
+}
+
 const stubQuestions = async () => {
   await stubQuestionGroup('1234')
   await stubQuestionGroup('22222222-2222-2222-2222-222222222203')
@@ -443,4 +459,5 @@ module.exports = {
   stubPredictors,
   stubRegistrations,
   stubRoshRiskSummary,
+  stubDocumentUpload,
 }

--- a/wiremock/stub.js
+++ b/wiremock/stub.js
@@ -16,6 +16,7 @@ const {
   stubTableActions,
   stubRegistrations,
   stubRoshRiskSummary,
+  stubDocumentUpload,
 } = require('./assessmentApi')
 const { stubGetAssessmentFromDelius, stubPostAssessmentFromDelius } = require('./assessmentFromDelius')
 const { stubStart } = require('./start')
@@ -62,6 +63,7 @@ async function stub() {
   await stubPredictors()
   await stubRegistrations()
   await stubRoshRiskSummary()
+  await stubDocumentUpload()
 }
 
 stub()


### PR DESCRIPTION
This PR creates a controller for the confirmation page with the following behaviour

- Convert HTML template to PDF using Gotenberg
- Upload the PDF document to Delius via the Assessments API
- Handle conversion errors by redirecting to the error page
- Handle 4xx errors by redirecting to the error page
- Handle 5xx "Delius is down" errors by redirecting to the bespoke error page