### PR TITLE
Arn 806 app insights

### DIFF
--- a/app/upw/controllers/convertPdf.js
+++ b/app/upw/controllers/convertPdf.js
@@ -4,10 +4,14 @@ const nunjucks = require('nunjucks')
 const superagent = require('superagent')
 const SaveAndContinue = require('./saveAndContinue')
 const { apis } = require('../../../common/config')
+const { trackEvent } = require('../../../common/logging/app-insights')
+const { EVENTS } = require('../../../common/utils/constants')
 
 class ConvertPdf extends SaveAndContinue {
   async render(req, res, next) {
     try {
+      trackEvent(EVENTS.ARN_PDF_DOWNLOAD, req)
+
       const rendered = nunjucks.render('app/upw/templates/pdf-preview-and-declaration/pdf.njk', {
         ...res.locals,
         css_path: 'application.min.css',

--- a/app/upw/controllers/saveAndContinue.js
+++ b/app/upw/controllers/saveAndContinue.js
@@ -1,5 +1,7 @@
+const { trackEvent } = require('../../../common/logging/app-insights')
 const BaseSaveAndContinue = require('../../common/controllers/saveAndContinue')
 const { getRegistrations, getRoshRiskSummary } = require('./common.utils')
+const { EVENTS, SECTION_COMPLETE } = require('../../../common/utils/constants')
 
 const removeAnswers = fieldsToRemove => answers =>
   Object.entries(answers).reduce((modifiedAnswers, [fieldName, answer]) => {
@@ -29,6 +31,10 @@ class SaveAndContinue extends BaseSaveAndContinue {
     const deliusRegistrations = await getRegistrations(req.session.assessment?.subject?.crn, req.user)
     const roshRiskSummary = await getRoshRiskSummary(req.session.assessment?.subject?.crn, req.user)
 
+    if (roshRiskSummary.roshRiskSummary?.overallRisk === 'NOT_KNOWN') {
+      trackEvent(EVENTS.ARN_NO_ROSH_DATA_AVAILABLE, req)
+    }
+
     res.locals.widgetData = {
       ...deliusRegistrations,
       ...roshRiskSummary,
@@ -43,11 +49,11 @@ class SaveAndContinue extends BaseSaveAndContinue {
 
     if (validationErrors.length > 0) {
       answers = invalidateSectionCompleteAnswers(answers, sectionCompleteFields)
+      req.sessionModel.set('formAnswers', answers)
+    } else {
+      trackEvent(EVENTS.ARN_SECTION_STARTED, req, { sectionName: req.form?.options?.pageTitle })
     }
 
-    if (validationErrors.length > 0) {
-      req.sessionModel.set('formAnswers', answers)
-    }
     res.locals.answers = answers
   }
 
@@ -57,6 +63,19 @@ class SaveAndContinue extends BaseSaveAndContinue {
     req.sessionModel.set('answers', answersWithInvalidatedDeclarations)
 
     super.saveValues(req, res, next)
+  }
+
+  successHandler(req, res, next) {
+    const sectionCompleteFields = Object.keys(req.form?.options?.fields).filter(key => key.match(/^\w+_complete$/))
+    const answers = req.sessionModel.get('answers')
+    const sectionComplete = answers[sectionCompleteFields[0]] === SECTION_COMPLETE
+
+    trackEvent(EVENTS.ARN_SECTION_COMPLETED, req, {
+      sectionName: req.form?.options?.pageTitle,
+      completed: sectionComplete,
+    })
+
+    super.successHandler(req, res, next)
   }
 }
 

--- a/app/upw/controllers/start.js
+++ b/app/upw/controllers/start.js
@@ -1,9 +1,13 @@
 const BaseController = require('../../common/controllers/baseController')
+const { trackEvent } = require('../../../common/logging/app-insights')
+const { EVENTS } = require('../../../common/utils/constants')
 
 class StartUnpaidWork extends BaseController {
   locals(req, res, next) {
     res.locals.pageDescription =
       'Your answers will be combined with OASys and nDelius information to create a PDF.<br>If you know nDelius and OASys information about the person needs changing, we advise you to do that before starting the assessment.'
+
+    trackEvent(EVENTS.ARN_SESSION_STARTED, req)
 
     super.locals(req, res, next)
   }

--- a/common/logging/app-insights.js
+++ b/common/logging/app-insights.js
@@ -1,0 +1,19 @@
+const appInsights = require('applicationinsights')
+
+const trackEvent = (eventName, req = {}, customProperties = {}) => {
+  const assessmentInfo = req.session?.assessment
+
+  const client = appInsights.defaultClient
+  if (client && eventName) {
+    const eventProperties = {
+      ...customProperties,
+      assessmentUuid: assessmentInfo?.uuid,
+      episodeUuid: assessmentInfo?.episodeUuid,
+      crn: assessmentInfo?.subject?.crn,
+      author: req.user?.username,
+    }
+    client.trackEvent({ name: eventName, properties: { ...eventProperties } })
+  }
+}
+
+module.exports = { trackEvent }

--- a/common/utils/constants.js
+++ b/common/utils/constants.js
@@ -6,6 +6,14 @@ const STANDALONE_ASSESSMENTS = ['UPW', 'RSR', 'UNPAID_WORK']
 const SECTION_INCOMPLETE = 'NO_ILL_COME_BACK_LATER'
 const SECTION_COMPLETE = 'YES'
 
+const EVENTS = {
+  ARN_NO_ROSH_DATA_AVAILABLE: 'arnNoRoshDataAvailable',
+  ARN_SESSION_STARTED: 'arnSessionStarted',
+  ARN_PDF_DOWNLOAD: 'arnPdfDownload',
+  ARN_SECTION_STARTED: 'arnSectionStarted',
+  ARN_SECTION_COMPLETED: 'arnSectionCompleted',
+}
+
 module.exports = Object.freeze({
   UUID_REGEX,
   REFRESH_TOKEN_LIFETIME_SECONDS,
@@ -14,4 +22,5 @@ module.exports = Object.freeze({
   STANDALONE_ASSESSMENTS,
   SECTION_INCOMPLETE,
   SECTION_COMPLETE,
+  EVENTS,
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1112,9 +1112,9 @@
       "dev": true
     },
     "@cypress/request": {
-      "version": "2.88.6",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.6.tgz",
-      "integrity": "sha512-z0UxBE/+qaESAHY9p9sM2h8Y4XqtsbDCt0/DPOrqA/RZgKi4PkxdpXyK4wCCnSk1xHqWHZZAE+gV6aDAR6+caQ==",
+      "version": "2.88.8",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.8.tgz",
+      "integrity": "sha512-AH5tOf091VvzaQiScVPqKMvLKft7yeEIxrKMpMTAlvCYUZDHkfp10igx31ppZVVaBM/XHYnoQ2Yt0oJuCJRPxw==",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -1124,8 +1124,7 @@
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
         "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
+        "http-signature": "~1.3.6",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
         "json-stringify-safe": "~5.0.1",
@@ -1138,6 +1137,42 @@
         "uuid": "^8.3.2"
       },
       "dependencies": {
+        "http-signature": {
+          "version": "1.3.6",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
+          "integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
+          "dev": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^2.0.2",
+            "sshpk": "^1.14.1"
+          }
+        },
+        "json-schema": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+          "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+        },
+        "jsprim": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
+          "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
+          "dev": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.4.0",
+            "verror": "1.10.0"
+          },
+          "dependencies": {
+            "json-schema": {
+              "version": "0.4.0",
+              "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+              "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+              "dev": true
+            }
+          }
+        },
         "qs": {
           "version": "6.5.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -9126,11 +9161,6 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -9204,6 +9234,13 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      },
+      "dependencies": {
+        "json-schema": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+          "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+        }
       }
     },
     "jwa": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "copy-govuk-assets": "copyfiles -u 1 node_modules/govuk-frontend/govuk/assets/fonts/**/* -f public/assets/fonts && copyfiles -u 1 node_modules/govuk-frontend/govuk/assets/images/**/* -f public/assets/images",
     "compile-sass": "sass --load-path node_modules/ common/assets/sass:public/stylesheets",
     "cssmin": "cleancss -o public/stylesheets/application.min.css public/stylesheets/application.css",
+    "security_audit": "npm audit",
     "server": "node ./start.js",
     "start": "npm run clean && npm run build && node ./start.js",
     "start:local": "npm run clean && npm run build && npm run setupStubs && NODE_ENV=local node ./start.js & npm run watch",

--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     ]
   },
   "resolutions": {
-    "ansi-regex": "5.0.1"
+    "ansi-regex": "5.0.1",
+    "json-schema": "^0.4.0"
   }
 }


### PR DESCRIPTION
Adds basic Application Insights event tracking.

Events fired are: 
- **arnNoRoshDataAvailable** - whenever a ROSH check is done and there is no OVERALL_RISK data. A future enhancement might be to cache the ROSH data so the call only happens once per session.
- **arnSessionStarted** - when the Unpaid Work start page is displayed
- **arnPdfDownload** - when the PDF is downloaded
- **arnSectionStarted** - when a section is started. Custom property 'sectionName' is also added the the title of the current page
- **arnSectionCompleted** - when the user completes a page. Custom properties 'sectionName' (title of the current page) and 'completed' (a boolean which is true if the user selected 'yes' to the section complete question). 

Other data included with each event call are:
- assessmentUuid
- episodeUuid
- crn
- author