### PR TITLE
Fix bug with missing DoB on the UPW PDF

### DIFF
--- a/app/upw/templates/pdf-preview-and-declaration/components/pdf-template/template.njk
+++ b/app/upw/templates/pdf-preview-and-declaration/components/pdf-template/template.njk
@@ -109,13 +109,13 @@
     {{ renderTable({
         caption: "Personal details",
         rows: [
-            { heading: "Family name", data: renderValue(rawAnswers["family_name"]) },
-            { heading: "First name", data: renderValue(rawAnswers["first_name"]) },
-            { heading: "Date of birth", data: renderDate(rawAnswers["dob"]) },
-            { heading: "CRN", data: renderValue(rawAnswers["crn"]) },
-            { heading: "PNC", data: renderValue(rawAnswers["pnc"]) },
+            { heading: "Family name", data: renderValue(rawAnswers["family_name"][0]) },
+            { heading: "First name", data: renderValue(rawAnswers["first_name"][0]) },
+            { heading: "Date of birth", data: renderDate(rawAnswers["dob"][0]) },
+            { heading: "CRN", data: renderValue(rawAnswers["crn"][0]) },
+            { heading: "PNC", data: renderValue(rawAnswers["pnc"][0]) },
             { heading: "Alias", data: renderAliases(rawAnswers['first_name_aliases'], rawAnswers['family_name_aliases']) },
-            { heading: "Ethnicity", data: renderValue(rawAnswers["ethnicity"]) }
+            { heading: "Ethnicity", data: renderValue(rawAnswers["ethnicity"][0]) }
         ]
     }) }}
 

--- a/common/utils/util.test.js
+++ b/common/utils/util.test.js
@@ -164,6 +164,7 @@ describe('extractLink', () => {
 describe('prettyDate', () => {
   it('formats date', () => {
     expect(prettyDate('2021-11-30T07:05:20+0000')).toEqual('30th November 2021')
+    expect(prettyDate('2021-11-30')).toEqual('30th November 2021')
   })
 
   it('handles invalid dates', () => {


### PR DESCRIPTION
Fixes and issue with the DoB missing from the PDF. We weren't accessing the `rawAnswers[field]` correctly in the template and the `prettyDate` function was returning `null`. I've also included coverage for ISO Date values when calling `prettyDate` as I noticed this is the format for the DoB field.