### PR TITLE
Add endpoint to close an assessment

### DIFF
--- a/app/upw/controllers/closeAssessment.js
+++ b/app/upw/controllers/closeAssessment.js
@@ -1,0 +1,28 @@
+/* eslint-disable class-methods-use-this */
+const SaveAndContinue = require('./saveAndContinue')
+const { closeAssessment } = require('../../../common/data/hmppsAssessmentApi')
+
+class CloseAssessment extends SaveAndContinue {
+  async render(req, res, next) {
+    try {
+      const [assessmentClosed] = await closeAssessment(
+        req.session.assessment.uuid,
+        req.session.assessment.episodeUuid,
+        req.user,
+      )
+
+      if (!assessmentClosed) {
+        throw new Error('Failed to close the assessment')
+      }
+
+      delete req.session.assessment
+      req.session.save()
+
+      return super.render(req, res, next)
+    } catch (e) {
+      return next(e)
+    }
+  }
+}
+
+module.exports = CloseAssessment

--- a/app/upw/controllers/closeAssessment.test.js
+++ b/app/upw/controllers/closeAssessment.test.js
@@ -1,0 +1,116 @@
+const { Controller } = require('hmpo-form-wizard')
+
+const CloseAssessmentController = require('./closeAssessment')
+const hmppsAssessmentsApiClient = require('../../../common/data/hmppsAssessmentApi')
+
+jest.mock('../../../common/data/hmppsAssessmentApi')
+jest.mock('../../../common/utils/util', () => ({
+  getCorrelationId: jest.fn(() => 'mocked-correlation-id'),
+}))
+jest.mock('../../../common/data/userDetailsCache', () => ({
+  getCachedUserDetails: jest.fn(() => ({
+    isActive: true,
+    oasysUserCode: 'SUPPORT1',
+    username: 'Ray Arnold',
+    email: 'foo@bar.baz',
+    areaCode: 'HFS',
+    areaName: 'Hertfordshire',
+  })),
+}))
+
+describe('CloseAssessmentController', () => {
+  describe('Render', () => {
+    const superMethod = jest.spyOn(Controller.prototype, 'render')
+    const controller = new CloseAssessmentController({
+      route: 'test-route',
+    })
+
+    let req
+    const user = { token: 'mytoken', id: '1' }
+    const assessmentUuid = '22222222-2222-2222-2222-222222222221'
+    const episodeUuid = '22222222-2222-2222-2222-222222222222'
+
+    const res = {
+      redirect: jest.fn(),
+      render: jest.fn(),
+      send: jest.fn(),
+      set: jest.fn(),
+      locals: {
+        'csrf-token': 'CSRF_TOKEN',
+        rawAnswers: {
+          first_name: 'Robert',
+          last_name: 'Robertson',
+          crn: 'X123456',
+        },
+      },
+    }
+
+    const next = jest.fn()
+
+    beforeEach(() => {
+      req = {
+        user,
+        body: {},
+        sessionModel: {
+          set: jest.fn(),
+          get: jest.fn(),
+        },
+        session: {
+          assessment: {
+            uuid: assessmentUuid,
+            episodeUuid,
+            subject: { dob: '1980-01-01' },
+          },
+          save: jest.fn(),
+        },
+        form: {
+          options: {
+            allFields: {},
+            fields: {},
+            journeyName: 'UPW',
+          },
+          values: {},
+        },
+      }
+
+      res.render.mockReset()
+      res.send.mockReset()
+      res.set.mockReset()
+      req.sessionModel.get.mockReset()
+      req.sessionModel.set.mockReset()
+      req.form.options.fields = {}
+      req.form.options.allFields = {}
+      next.mockReset()
+      hmppsAssessmentsApiClient.closeAssessment.mockReset()
+      superMethod.mockReset()
+      req.session.save.mockReset()
+    })
+
+    it('closes an assessment', async () => {
+      hmppsAssessmentsApiClient.closeAssessment.mockResolvedValue([true])
+
+      await controller.render(req, res, next)
+
+      expect(hmppsAssessmentsApiClient.closeAssessment).toHaveBeenCalledWith(assessmentUuid, episodeUuid, user)
+      expect(superMethod).toHaveBeenCalled()
+    })
+
+    it('removes the assessment from session', async () => {
+      hmppsAssessmentsApiClient.closeAssessment.mockResolvedValue([true])
+
+      await controller.render(req, res, next)
+
+      expect(req.session.assessment).toBeUndefined()
+      expect(req.session.save).toHaveBeenCalled()
+      expect(superMethod).toHaveBeenCalled()
+    })
+
+    it('passes an error to the error handler when unable to close the assessment', async () => {
+      hmppsAssessmentsApiClient.closeAssessment.mockResolvedValue([false])
+
+      await controller.render(req, res, next)
+
+      expect(next).toHaveBeenCalledWith(new Error('Failed to close the assessment'))
+    })
+  })
+})

--- a/app/upw/steps.js
+++ b/app/upw/steps.js
@@ -4,6 +4,7 @@ const SaveAndContinue = require('./controllers/saveAndContinue')
 const ConvertPdf = require('./controllers/convertPdf')
 const Declaration = require('./controllers/declaration')
 const Confirmation = require('./controllers/confirmation')
+const CloseAssessment = require('./controllers/closeAssessment')
 
 module.exports = {
   '/start': {
@@ -322,5 +323,11 @@ module.exports = {
     pageTitle: 'Privacy notice',
     noPost: true,
     template: `${__dirname}/templates/privacy.njk`,
+  },
+  '/close-assessment': {
+    pageTitle: 'Assessment closed',
+    controller: CloseAssessment,
+    noPost: true,
+    template: `${__dirname}/templates/close-assessment.njk`,
   },
 }

--- a/app/upw/templates/close-assessment.njk
+++ b/app/upw/templates/close-assessment.njk
@@ -1,0 +1,25 @@
+{% extends "common/templates/layout.njk" %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{%- set hideBackLink = true -%}
+
+{% block pageTitle %}
+{{ pageTitle }}
+{% endblock %}
+
+{% block header %}
+{% include "common/templates/partials/header.njk" %}
+{% endblock %}
+
+{% block content %}
+{{ super() }}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        {{ govukPanel({
+            titleText: "The assessment has been closed",
+            classes: "upw-confirmation-panel"
+        }) }}
+    </div>
+</div>
+{% endblock %}

--- a/common/data/hmppsAssessmentApi.js
+++ b/common/data/hmppsAssessmentApi.js
@@ -69,6 +69,13 @@ const postAnswers = (assessmentId, episodeId, answers, authorisationToken, userI
   return postData(path, authorisationToken, userId, answers)
 }
 
+const closeAssessment = (assessmentId, episodeId, user) => {
+  const path = `${url}/assessments/${assessmentId}/episodes/${episodeId}/close`
+
+  logger.info(`Calling hmppsAssessments API with GET: ${path}`)
+  return action(superagent.get(path), user?.token, user?.id)
+}
+
 const postTableRow = (assessmentId, episodeId, tableName, answers, authorisationToken, userId) => {
   const path = `${url}/assessments/${assessmentId}/episodes/${episodeId}/table/${tableName}`
   return postData(path, authorisationToken, userId, answers)
@@ -229,4 +236,5 @@ module.exports = {
   getRegistrationsForCrn,
   getRoshRiskSummaryForCrn,
   uploadPdfDocumentToDelius,
+  closeAssessment,
 }

--- a/integration-tests/plugins/index.js
+++ b/integration-tests/plugins/index.js
@@ -17,6 +17,7 @@ const {
   stubRegistrations,
   stubRoshRiskSummary,
   stubDocumentUpload,
+  stubCloseAssessment,
 } = require('../../wiremock/assessmentApi')
 const { stubReferenceData } = require('../../wiremock/referenceData')
 const { stubAuth, getLoginUrl } = require('../../wiremock/auth')
@@ -51,6 +52,7 @@ module.exports = on => {
         stubRegistrations(),
         stubRoshRiskSummary(),
         stubDocumentUpload(),
+        stubCloseAssessment(),
       ]),
     stubGetUserProfileWithSingleArea: () => Promise.all([stubGetUserProfileWithSingleArea()]),
     stubGetUserProfileWithMultipleAreas: () => Promise.all([stubGetUserProfile()]),

--- a/wiremock/assessmentApi.js
+++ b/wiremock/assessmentApi.js
@@ -373,6 +373,21 @@ const stubDocumentUpload = () => {
   })
 }
 
+const stubCloseAssessment = () => {
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: `/assessments/.+?/episodes/.+?/close`,
+    },
+    response: {
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      status: 200,
+    },
+  })
+}
+
 const stubQuestions = async () => {
   await stubQuestionGroup('1234')
   await stubQuestionGroup('22222222-2222-2222-2222-222222222203')
@@ -460,4 +475,5 @@ module.exports = {
   stubRegistrations,
   stubRoshRiskSummary,
   stubDocumentUpload,
+  stubCloseAssessment,
 }

--- a/wiremock/stub.js
+++ b/wiremock/stub.js
@@ -17,6 +17,7 @@ const {
   stubRegistrations,
   stubRoshRiskSummary,
   stubDocumentUpload,
+  stubCloseAssessment,
 } = require('./assessmentApi')
 const { stubGetAssessmentFromDelius, stubPostAssessmentFromDelius } = require('./assessmentFromDelius')
 const { stubStart } = require('./start')
@@ -64,6 +65,7 @@ async function stub() {
   await stubRegistrations()
   await stubRoshRiskSummary()
   await stubDocumentUpload()
+  await stubCloseAssessment()
 }
 
 stub()


### PR DESCRIPTION
This PR creates an endpoint `/UPW/close-assessment` that will close the currently selected assessment. It has currently no link in the UI, this however could be added later following the design/content around this.