### PR TITLE
Update use to contain full name

### DIFF
--- a/app/upw/templates/pdf-preview-and-declaration/pdf-preview.njk
+++ b/app/upw/templates/pdf-preview-and-declaration/pdf-preview.njk
@@ -15,7 +15,7 @@
 {# include errorSummary partial #}
 {{ super() }}
 
-{{ renderPdfTemplate(assessment, answers, rawAnswers, widgetData, username, {
+{{ renderPdfTemplate(assessment, answers, rawAnswers, widgetData, userFullName, {
     imageAssetPath: "/assets/images/"
 }) }}
 

--- a/app/upw/templates/pdf-preview-and-declaration/pdf.njk
+++ b/app/upw/templates/pdf-preview-and-declaration/pdf.njk
@@ -14,7 +14,7 @@
 {# include errorSummary partial #}
 {{ super() }}
 
-{{ renderPdfTemplate(assessment, answers, rawAnswers, widgetData, username) }}
+{{ renderPdfTemplate(assessment, answers, rawAnswers, widgetData, userFullName) }}
 
 {% endblock %}
 

--- a/common/data/userDetailsCache.js
+++ b/common/data/userDetailsCache.js
@@ -17,7 +17,8 @@ const cacheOasysUserDetails = async (userId, oasysUser) => {
 
 const cacheUserDetails = async user => {
   const userDetails = {
-    username: `${user?.user_name}`,
+    username: user?.user_name,
+    name: user?.name,
   }
 
   await redis.set(`user:${user?.user_id}`, JSON.stringify(userDetails), 'EX', REFRESH_TOKEN_LIFETIME_SECONDS)

--- a/common/middleware/add-user-information.js
+++ b/common/middleware/add-user-information.js
@@ -2,5 +2,6 @@
 
 module.exports = (req, res, next) => {
   res.locals.username = req.user?.username
+  res.locals.userFullName = req.user?.name
   next()
 }

--- a/common/middleware/add-user-information.test.js
+++ b/common/middleware/add-user-information.test.js
@@ -6,7 +6,7 @@ describe('Put keycloak header information into session', () => {
   let res
   beforeEach(() => {
     req = {
-      user: { username: 'James' },
+      user: { username: 'JBOND', name: 'James Bond' },
     }
     res = {
       locals: {},
@@ -15,13 +15,7 @@ describe('Put keycloak header information into session', () => {
 
   test('should add user name to locals', done => {
     addUserInformation(req, res, done)
-    expect(res.locals.username).toEqual('James')
+    expect(res.locals.username).toEqual('JBOND')
+    expect(res.locals.userFullName).toEqual('James Bond')
   })
-
-  // test('should throw an error if "x-auth-name" is not in session', () => {
-  //   req.headers = {}
-  //   expect(() => {
-  //     addUserInformation(req, res, () => {})
-  //   }).toThrowError('Username (x-auth-name) not found in session')
-  // })
 })

--- a/common/middleware/auth.test.js
+++ b/common/middleware/auth.test.js
@@ -397,7 +397,8 @@ describe('Auth', () => {
           JSON.stringify({
             isActive: true,
             oasysUserCode: 'SUPPORT1',
-            username: 'Foo',
+            username: 'FBAR',
+            name: 'Foo Bar',
             email: 'foo@bar.baz',
             areaCode: 'HFS',
             areaName: 'Hertfordshire',
@@ -411,7 +412,8 @@ describe('Auth', () => {
         User.from({
           id: 1,
           token: 'FOO_TOKEN',
-          username: 'Foo',
+          username: 'FBAR',
+          name: 'Foo Bar',
           email: 'foo@bar.baz',
           isActive: true,
           oasysUserCode: 'SUPPORT1',
@@ -426,7 +428,8 @@ describe('Auth', () => {
 
       expect(error).toBeNull()
       expect(user.getDetails()).toEqual({
-        username: 'Foo',
+        username: 'FBAR',
+        name: 'Foo Bar',
         email: 'foo@bar.baz',
         isActive: true,
         oasysUserCode: 'SUPPORT1',
@@ -448,7 +451,8 @@ describe('Auth', () => {
       getCachedUserDetails.mockResolvedValue(null)
       cacheOasysUserDetails.mockResolvedValue({
         oasysUserCode: 'USER_CODE',
-        username: 'Test User',
+        username: 'FBAR',
+        name: 'Foo Bar',
         email: 'foo@bar.baz',
         isActive: true,
       })
@@ -474,7 +478,8 @@ describe('Auth', () => {
 
       expect(error).toBeNull()
       expect(user.getDetails()).toEqual({
-        username: 'Test User',
+        username: 'FBAR',
+        name: 'Foo Bar',
         email: 'foo@bar.baz',
         isActive: true,
         oasysUserCode: 'USER_CODE',

--- a/common/models/user.js
+++ b/common/models/user.js
@@ -16,11 +16,12 @@ class User {
     return this
   }
 
-  withDetails({ isActive, email, oasysUserCode, username, areaCode, areaName } = {}) {
+  withDetails({ isActive, email, oasysUserCode, username, name, areaCode, areaName } = {}) {
     this.isActive = isActive
     this.email = email
     this.oasysUserCode = oasysUserCode
     this.username = username
+    this.name = name || username
     this.areaCode = areaCode
     this.areaName = areaName
     return this
@@ -32,6 +33,7 @@ class User {
       email: this.email,
       oasysUserCode: this.oasysUserCode,
       username: this.username,
+      name: this.name,
       areaCode: this.areaCode,
       areaName: this.areaName,
     }


### PR DESCRIPTION
This PR intends to update the `User` model to store the `name` in the JWT. Looking at the JWT for my user when signed in, it looks like this might allow us to display the user's full name for the PDF template
```
...
{
  "sub": "LCAIRNS",
  "user_name": "LCAIRNS",
  "name": "Lucas Cairns",
  ...
}
...
```
I've also made sure we fallback to the `user_name` if the `name` attribute is for whatever reason unavailable