### PR TITLE
Arn 865 UPW feedback banner

### DIFF
--- a/app/upw/index.js
+++ b/app/upw/index.js
@@ -2,11 +2,13 @@ const { Router } = require('express')
 const wizard = require('hmpo-form-wizard')
 const steps = require('./steps')
 const { fields } = require('./fields')
+const config = require('./upw_config')
 
 const router = Router()
 
 router.get('*', (req, res, next) => {
   res.locals.pageTitle = steps[req.url]?.pageTitle
+  res.locals.feedbackUrl = config.feedback_banner.url || ''
   next()
 })
 

--- a/app/upw/upw_config.js
+++ b/app/upw/upw_config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  feedback_banner: {
+    url: 'https://forms.office.com/r/f49pD4dkqU',
+  },
+}

--- a/common/assets/sass/application.scss
+++ b/common/assets/sass/application.scss
@@ -236,5 +236,5 @@ p {
 }
 
 .upw-feedback-banner__text {
-  color: #ffffff;
+  color: #fff;
 }

--- a/common/assets/sass/application.scss
+++ b/common/assets/sass/application.scss
@@ -236,5 +236,5 @@ p {
 }
 
 .upw-feedback-banner__text {
-  color: white;
+  color: #ffffff;
 }

--- a/common/assets/sass/application.scss
+++ b/common/assets/sass/application.scss
@@ -229,3 +229,12 @@ p {
 .govuk-radios__conditional .govuk-label--m {
   @extend .govuk-label;
 }
+
+.feedback-banner {
+  background: $govuk-brand-colour;
+  padding: govuk-spacing(3);
+}
+
+.upw-feedback-banner__text {
+  color: white;
+}

--- a/common/templates/components/feedbackBanner/feedbackBanner.njk
+++ b/common/templates/components/feedbackBanner/feedbackBanner.njk
@@ -1,0 +1,6 @@
+{% if feedbackUrl %}
+<div class="feedback-banner" data-test="feedback-banner">
+  <span class='govuk-body-s upw-feedback-banner__text'>This is a new service. <a href="{{ feedbackUrl }}" class="govuk-link govuk-link--inverse" target="_blank" rel="noopener noreferrer">
+      Give feedback to help us improve it or report a problem</a> (opens in a new tab)</span>
+</div>
+{% endif %}

--- a/common/templates/layout.njk
+++ b/common/templates/layout.njk
@@ -37,8 +37,16 @@
 {% endblock %}
 
 {% block footer %}
+
+  <div style="background: {{ feedbackBannerBackground or '#fff' }}" class="govuk-!-display-none-print">
+    <div class="govuk-width-container {{ containerClasses }}">
+      {% include "../templates/components/feedbackBanner/feedbackBanner.njk" %}
+    </div>
+  </div>
+
   {{
     govukFooter({
+      containerClasses: containerClasses,
       meta: {
         items: [
           {

--- a/common/templates/partials/header.njk
+++ b/common/templates/partials/header.njk
@@ -11,7 +11,7 @@
 
       <a class="moj-header__link moj-header__link--organisation-name" href="/">HMPPS</a>
       <a class="moj-header__link moj-header__link--service-name" href="/">Assess risks and needs</a>
-      <div class="pac-phase-tag"><strong class="govuk-tag pac-header-tag">Alpha</strong></div>
+      <div class="pac-phase-tag"><strong class="govuk-tag pac-header-tag">Beta</strong></div>
 
     </div>
     <div class="moj-header__content">


### PR DESCRIPTION
Adds a banner in the footer to link to the feedback form. Adds in a config file for the URL (which can be extended for other items later), and adds the URL to locals for the template to pick up.

Note that the banner does not show if the URL is not in locals, so other services will not show the banner until an appropriate config is added.

This PR also fixes the width of the template footers and changes the service status to 'Beta'.  