### PR TITLE
removed unnecessary second heading in cookies.njk

### DIFF
--- a/app/upw/templates/cookies.njk
+++ b/app/upw/templates/cookies.njk
@@ -34,7 +34,6 @@
         <p>Essential cookies keep your information secure while you use Community Payback Assessment. We do not need to ask permission to use them.</p>
         
         {{ govukTable({
-        caption: "Essential cookies",
         captionClasses: "govuk-table__caption--m",
         firstCellIsHeader: true,
         head: [
@@ -51,7 +50,7 @@
         rows: [
           [
             {  
-               text: "Connect.sid"
+               text: "connect.sid"
             },
             {
                text: "Keeps you logged into the service"


### PR DESCRIPTION
The cookie template had two 'Essential cookies' headings. One was removed.