### PR TITLE
Moved docker build to latest version of node LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.13.1-bullseye-slim
+FROM node:16.14-bullseye-slim
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 ARG BUILD_NUMBER
 ARG GIT_REF


### PR DESCRIPTION
This hopefully will address some of the Trivy scan alerts the UI has been getting.