### PR TITLE
Arn 960 add spellchecker attribute

### DIFF
--- a/app/common/controllers/saveAndContinue.test.js
+++ b/app/common/controllers/saveAndContinue.test.js
@@ -1,10 +1,11 @@
 const { configure } = require('nunjucks')
 const SaveAndContinueController = require('./saveAndContinue')
 const { getAnswers, postAnswers, getFlatAssessmentQuestions } = require('../../../common/data/hmppsAssessmentApi')
-const { processReplacements, encodeHTML } = require('../../../common/utils/util')
+const { processReplacements, encodeHTML, updateJsonValue } = require('../../../common/utils/util')
 
 const nunjucksEnvironment = configure({}, {})
 nunjucksEnvironment.addFilter('encodeHtml', str => encodeHTML(str))
+nunjucksEnvironment.addFilter('addSpellcheck', jsonObj => updateJsonValue(jsonObj, 'spellcheck', true, true))
 
 jest.mock('../../../common/data/hmppsAssessmentApi')
 jest.mock('../../../common/utils/util')

--- a/app/questionGroup/fixtures/expected.json
+++ b/app/questionGroup/fixtures/expected.json
@@ -185,7 +185,7 @@
             }
           ],
           "conditional": {
-            "html": " <div class=\"govuk-character-count\" data-module=\"govuk-character-count\" data-maxlength=\"4000\"><div class=\"govuk-form-group\"><label class=\"govuk-label further_information govuk-label--m\" for=\"further_information\">Further information</label><div id=\"further_information-hint\" class=\"govuk-hint\"></div><textarea class=\"govuk-textarea govuk-js-character-count\" id=\"further_information\" name=\"further_information\" rows=\"5\" aria-describedby=\"further_information-info further_information-hint\"></textarea>\n</div><div id=\"further_information-info\" class=\"govuk-hint govuk-character-count__message\" aria-live=\"polite\">You can enter up to 4000 characters\n</div></div>"
+            "html": " <div class=\"govuk-character-count\" data-module=\"govuk-character-count\" data-maxlength=\"4000\"><div class=\"govuk-form-group\"><label class=\"govuk-label further_information govuk-label--m\" for=\"further_information\">Further information</label><div id=\"further_information-hint\" class=\"govuk-hint\"></div><textarea class=\"govuk-textarea govuk-js-character-count\" id=\"further_information\" name=\"further_information\" rows=\"5\" aria-describedby=\"further_information-info further_information-hint\" spellcheck=\"true\"></textarea>\n</div><div id=\"further_information-info\" class=\"govuk-hint govuk-character-count__message\" aria-live=\"polite\">You can enter up to 4000 characters\n</div></div>"
           }
         },
         {
@@ -353,7 +353,7 @@
             }
           ],
           "conditional": {
-            "html": " <div class=\"govuk-character-count\" data-module=\"govuk-character-count\" data-maxlength=\"4000\"><div class=\"govuk-form-group\"><label class=\"govuk-label drug_misuse_details govuk-label--m\" for=\"drug_misuse_details\">Give details</label><div id=\"drug_misuse_details-hint\" class=\"govuk-hint\"></div><textarea class=\"govuk-textarea govuk-js-character-count\" id=\"drug_misuse_details\" name=\"drug_misuse_details\" rows=\"5\" aria-describedby=\"drug_misuse_details-info drug_misuse_details-hint\"></textarea>\n</div><div id=\"drug_misuse_details-info\" class=\"govuk-hint govuk-character-count__message\" aria-live=\"polite\">You can enter up to 4000 characters\n</div></div>"
+            "html": " <div class=\"govuk-character-count\" data-module=\"govuk-character-count\" data-maxlength=\"4000\"><div class=\"govuk-form-group\"><label class=\"govuk-label drug_misuse_details govuk-label--m\" for=\"drug_misuse_details\">Give details</label><div id=\"drug_misuse_details-hint\" class=\"govuk-hint\"></div><textarea class=\"govuk-textarea govuk-js-character-count\" id=\"drug_misuse_details\" name=\"drug_misuse_details\" rows=\"5\" aria-describedby=\"drug_misuse_details-info drug_misuse_details-hint\" spellcheck=\"true\"></textarea>\n</div><div id=\"drug_misuse_details-info\" class=\"govuk-hint govuk-character-count__message\" aria-live=\"polite\">You can enter up to 4000 characters\n</div></div>"
           },
           "attributes": [
             ["data-conditional", "drug_misuse_frequency drug_misuse_motivation"],
@@ -396,7 +396,7 @@
             }
           ],
           "conditional": {
-            "html": " <div class=\"govuk-character-count\" data-module=\"govuk-character-count\" data-maxlength=\"4000\"><div class=\"govuk-form-group\"><label class=\"govuk-label give_details govuk-label--m\" for=\"give_details\">Give details</label><div id=\"give_details-hint\" class=\"govuk-hint\"></div><textarea class=\"govuk-textarea govuk-js-character-count\" id=\"give_details\" name=\"give_details\" rows=\"5\" aria-describedby=\"give_details-info give_details-hint\"></textarea>\n</div><div id=\"give_details-info\" class=\"govuk-hint govuk-character-count__message\" aria-live=\"polite\">You can enter up to 4000 characters\n</div></div>"
+            "html": " <div class=\"govuk-character-count\" data-module=\"govuk-character-count\" data-maxlength=\"4000\"><div class=\"govuk-form-group\"><label class=\"govuk-label give_details govuk-label--m\" for=\"give_details\">Give details</label><div id=\"give_details-hint\" class=\"govuk-hint\"></div><textarea class=\"govuk-textarea govuk-js-character-count\" id=\"give_details\" name=\"give_details\" rows=\"5\" aria-describedby=\"give_details-info give_details-hint\" spellcheck=\"true\"></textarea>\n</div><div id=\"give_details-info\" class=\"govuk-hint govuk-character-count__message\" aria-live=\"polite\">You can enter up to 4000 characters\n</div></div>"
           }
         },
         {

--- a/app/questionGroup/get.controller.test.js
+++ b/app/questionGroup/get.controller.test.js
@@ -3,12 +3,13 @@ const { configure } = require('nunjucks')
 
 const nunjucksEnvironment = configure({}, {})
 const dateFilter = require('nunjucks-date-filter')
-const { encodeHTML } = require('../../common/utils/util')
+const { encodeHTML, updateJsonValue } = require('../../common/utils/util')
 const { mojDate } = require('../../node_modules/@ministryofjustice/frontend/moj/filters/all')()
 // add custom nunjucks filters
 nunjucksEnvironment.addFilter('date', dateFilter)
 nunjucksEnvironment.addFilter('mojDate', mojDate)
 nunjucksEnvironment.addFilter('encodeHtml', str => encodeHTML(str))
+nunjucksEnvironment.addFilter('addSpellcheck', jsonObj => updateJsonValue(jsonObj, 'spellcheck', true, true))
 
 const { displayQuestionGroup } = require('./get.controller')
 const { getAnswers } = require('../../common/data/hmppsAssessmentApi')

--- a/app/rsr/controllers/saveAndContinue.test.js
+++ b/app/rsr/controllers/saveAndContinue.test.js
@@ -2,10 +2,11 @@ const { configure } = require('nunjucks')
 const SaveAndContinueController = require('./saveAndContinue')
 const { getAnswers, postAnswers, getFlatAssessmentQuestions } = require('../../../common/data/hmppsAssessmentApi')
 const { customValidations } = require('../fields')
-const { processReplacements, encodeHTML } = require('../../../common/utils/util')
+const { processReplacements, encodeHTML, updateJsonValue } = require('../../../common/utils/util')
 
 const nunjucksEnvironment = configure({}, {})
 nunjucksEnvironment.addFilter('encodeHtml', str => encodeHTML(str))
+nunjucksEnvironment.addFilter('addSpellcheck', jsonObj => updateJsonValue(jsonObj, 'spellcheck', true, true))
 
 jest.mock('../../../common/data/hmppsAssessmentApi')
 jest.mock('../../../common/utils/util')

--- a/common/middleware/questionGroups/getHandlers.test.js
+++ b/common/middleware/questionGroups/getHandlers.test.js
@@ -4,11 +4,12 @@ const { configure } = require('nunjucks')
 const nunjucksEnvironment = configure({}, {})
 const dateFilter = require('nunjucks-date-filter')
 const { mojDate } = require('@ministryofjustice/frontend/moj/filters/all')()
-const { encodeHTML } = require('../../utils/util')
+const { encodeHTML, updateJsonValue } = require('../../utils/util')
 // add custom nunjucks filters
 nunjucksEnvironment.addFilter('date', dateFilter)
 nunjucksEnvironment.addFilter('mojDate', mojDate)
 nunjucksEnvironment.addFilter('encodeHtml', str => encodeHTML(str))
+nunjucksEnvironment.addFilter('addSpellcheck', jsonObj => updateJsonValue(jsonObj, 'spellcheck', true, true))
 
 const { compileInlineConditionalQuestions, annotateWithAnswers, transformTableEntries } = require('./getHandlers')
 
@@ -148,7 +149,7 @@ describe('getQuestionGroups', () => {
               answerSchemaUuid: '44444444-4444-4444-4444-444444444444',
               conditional: {
                 html:
-                  ' <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="4000"><div class="govuk-form-group"><label class="govuk-label further_information govuk-label--m" for="further_information">Further information</label><div id="further_information-hint" class="govuk-hint"></div><textarea class="govuk-textarea govuk-js-character-count" id="further_information" name="further_information" rows="5" aria-describedby="further_information-info further_information-hint"></textarea>\n</div><div id="further_information-info" class="govuk-hint govuk-character-count__message" aria-live="polite">You can enter up to 4000 characters\n</div></div>',
+                  ' <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="4000"><div class="govuk-form-group"><label class="govuk-label further_information govuk-label--m" for="further_information">Further information</label><div id="further_information-hint" class="govuk-hint"></div><textarea class="govuk-textarea govuk-js-character-count" id="further_information" name="further_information" rows="5" aria-describedby="further_information-info further_information-hint" spellcheck="true"></textarea>\n</div><div id="further_information-info" class="govuk-hint govuk-character-count__message" aria-live="polite">You can enter up to 4000 characters\n</div></div>',
               },
               conditionals: [
                 {

--- a/common/templates/components/question/template.njk
+++ b/common/templates/components/question/template.njk
@@ -221,7 +221,7 @@
         formGroup : {
           classes: formClass or question.formClasses
         },
-        attributes: question.attributes,
+        attributes: question.attributes | addSpellcheck,
         label: {
           text: question.questionText,
           isPageHeading: false,
@@ -247,7 +247,7 @@
       formGroup : {
         classes: question.formClasses
       },
-      attributes: question.attributes,
+      attributes: question.attributes | addSpellcheck,
       hint: {
         text: question.helpText
       },

--- a/common/utils/util.js
+++ b/common/utils/util.js
@@ -105,7 +105,11 @@ const encodeHTML = str => {
 }
 
 // used in nunjucks templates which doesn't support directly setting json values
-const updateJsonValue = (jsonObj, key, value) => {
+const updateJsonValue = (jsonObj, key, value, createNewObject = false) => {
+  if (!jsonObj && createNewObject) {
+    // eslint-disable-next-line no-param-reassign
+    jsonObj = {}
+  }
   if (!jsonObj) {
     return {}
   }

--- a/common/utils/util.js
+++ b/common/utils/util.js
@@ -113,6 +113,9 @@ const updateJsonValue = (jsonObj, key, value, createNewObject = false) => {
   if (!jsonObj) {
     return {}
   }
+  if (!key) {
+    return jsonObj
+  }
   // eslint-disable-next-line no-param-reassign
   jsonObj[key] = value
   return jsonObj

--- a/common/utils/util.test.js
+++ b/common/utils/util.test.js
@@ -11,6 +11,7 @@ const {
   prettyDateAndTime,
   prettyDate,
   ageFrom,
+  updateJsonValue,
 } = require('./util')
 
 const inputText = "There is a green hill far away - and I shouldn't tell you that really"
@@ -212,5 +213,37 @@ describe('ageFrom', () => {
 
   it('handles empty input', () => {
     expect(ageFrom()).toBeNull()
+  })
+})
+
+// unit tests for updateJsonValue object
+
+describe('tests for the updateJsonValue function', () => {
+  it('creates a json object when json object is null and createNewObject is true', () => {
+    const results = updateJsonValue(null, 'key', 'value', false)
+    expect(results).toEqual({}) // a new json object is created
+  })
+
+  it('creates an empty object when json object is null', () => {
+    const results = updateJsonValue(null, 'key', 'value', true)
+    expect(results).toEqual({ key: 'value' })
+  })
+
+  it('updates the keys value if it already exist', () => {
+    const myObject = { one: '1', two: '2', key: 'value' }
+    const results = updateJsonValue(myObject, 'key', 'newValue', false)
+    expect(results).toEqual({ one: '1', two: '2', key: 'newValue' })
+  })
+
+  it('updates the key value', () => {
+    const myObject = { one: '1', two: '2' }
+    const results = updateJsonValue(myObject, 'key', 'newValue', false)
+    expect(results).toEqual({ one: '1', two: '2', key: 'newValue' })
+  })
+
+  it('if a key is not defined, return a json object', () => {
+    const myObject = { one: '1', two: '2' }
+    const results = updateJsonValue(myObject, null, 'value', false)
+    expect(results).toEqual(myObject)
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -5625,7 +5625,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -28011,8 +28010,7 @@
     "mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "mkdirp-classic": {
       "version": "0.5.3",

--- a/server.js
+++ b/server.js
@@ -172,6 +172,7 @@ function initialiseTemplateEngine(app) {
   nunjucksEnvironment.addFilter('doReplace', (str, target, replacement) => doReplace(str, target, replacement))
   // typeof for array, using native JS Array.isArray()
   nunjucksEnvironment.addFilter('isArr', str => Array.isArray(str))
+  nunjucksEnvironment.addFilter('addSpellcheck', jsonObj => updateJsonValue(jsonObj, 'spellcheck', true, true))
   nunjucksEnvironment.addFilter('updateJsonValue', (jsonObj, keyToChange, newValue) =>
     updateJsonValue(jsonObj, keyToChange, newValue),
   )


### PR DESCRIPTION
This PR updates the templating for 'input' and 'textarea' components to add a 'spellchecker = true' attribute which will enable those fields to be exposed to in-browser spellchecking functionality where available. 