### PR TITLE
Temporarily upgrade packages in response to CVE-2022-1271

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ ARG GIT_REF
 
 RUN apt-get update && apt-get install -y make python3
 RUN apt-get install -y curl
+# temporary fix for avd.aquasec.com/nvd/cve-2022-1271
+RUN apt-get upgrade -y gzip=1.10-4+deb11u1 liblzma5=5.2.5-2.1~deb11u1
 RUN apt-get install build-essential -y
 
 ENV TZ=Europe/London


### PR DESCRIPTION
Relates to `avd.aquasec.com/nvd/cve-2022-1271`

This implements an additional stage in our Docker build to upgrade the `gzip` and `liblzma5` packages to their patched versions, this is temporary until it's patched in the base image.

```
#8 [ 5/16] RUN dpkg -l 'gzip*' | grep ^i
#8 sha256:e69956b53a8176294b3806fe9d3b86133475468e45f0271e96806edd22b5b98f
#8 0.299 ii  gzip           1.10-4+deb11u1 amd64        GNU compression utilities
#8 DONE 0.3s

#9 [ 6/16] RUN dpkg -l 'liblzma5*' | grep ^i
#9 sha256:7f516353e744850c51c85e91cb2cd7f6681ffeee6c562bec91b318722166cd02
#9 0.318 ii  liblzma5:amd64 5.2.5-2.1~deb11u1 amd64        XZ-format compression library
#9 DONE 0.3s
```