### PR TITLE
Update ROSH, MAPPA and Flags widgets error handling

### DIFF
--- a/app/upw/controllers/common.utils.js
+++ b/app/upw/controllers/common.utils.js
@@ -52,12 +52,25 @@ const getRegistrations = async (crn, user) => {
 
 const getRoshRiskSummary = async (crn, user) => {
   try {
-    const [, response] = await getRoshRiskSummaryForCrn(crn, user?.token, user?.id)
+    const { response, status } = await getRoshRiskSummaryForCrn(crn, user)
 
     const nullIfNotKnown = s => (s === 'NOT_KNOWN' ? null : s)
 
+    if (status === 404) {
+      return {
+        roshRiskSummary: { hasBeenCompleted: false },
+      }
+    }
+
+    if (status >= 400) {
+      return {
+        roshRiskSummary: null,
+      }
+    }
+
     return {
       roshRiskSummary: {
+        hasBeenCompleted: true,
         overallRisk: nullIfNotKnown(response.overallRisk),
         riskToChildren: nullIfNotKnown(response.riskToChildrenInCommunity),
         riskToPublic: nullIfNotKnown(response.riskToPublicInCommunity),

--- a/app/upw/controllers/common.utils.js
+++ b/app/upw/controllers/common.utils.js
@@ -38,7 +38,21 @@ const formatFlag = flag => flag.description || null
 
 const getRegistrations = async (crn, user) => {
   try {
-    const [, response] = await getRegistrationsForCrn(crn, user?.token, user?.id)
+    const { response, status } = await getRegistrationsForCrn(crn, user)
+
+    if (status === 404) {
+      return {
+        flags: [],
+        mappa: {},
+      }
+    }
+
+    if (status >= 400) {
+      return {
+        mappa: null,
+        flags: null,
+      }
+    }
 
     return {
       mappa: formatMappaResponse(response.mappa),
@@ -46,7 +60,7 @@ const getRegistrations = async (crn, user) => {
     }
   } catch (error) {
     logger.info(`Failed to fetch registrations for CRN ${crn}`)
-    return { flags: [] }
+    return { mappa: null, flags: null }
   }
 }
 

--- a/app/upw/controllers/common.utils.test.js
+++ b/app/upw/controllers/common.utils.test.js
@@ -7,9 +7,9 @@ const user = { id: 1, token: 'FOO_TOKEN' }
 
 describe('GetRegistrations', () => {
   it('returns MAPPA data', async () => {
-    getRegistrationsForCrn.mockResolvedValue([
-      true,
-      {
+    getRegistrationsForCrn.mockResolvedValue({
+      status: 200,
+      response: {
         mappa: {
           level: 'M1',
           levelDescription: 'MAPPA Level 1',
@@ -19,7 +19,7 @@ describe('GetRegistrations', () => {
         },
         flags: [],
       },
-    ])
+    })
 
     const registrations = await getRegistrations('A123456', user)
 
@@ -34,12 +34,12 @@ describe('GetRegistrations', () => {
   })
 
   it('handles when there is no MAPPA data', async () => {
-    getRegistrationsForCrn.mockResolvedValue([
-      true,
-      {
+    getRegistrationsForCrn.mockResolvedValue({
+      status: 200,
+      response: {
         flags: [],
       },
-    ])
+    })
 
     const registrations = await getRegistrations('A123456', user)
 
@@ -54,9 +54,9 @@ describe('GetRegistrations', () => {
   })
 
   it('handles when there is no MAPPA category', async () => {
-    getRegistrationsForCrn.mockResolvedValue([
-      true,
-      {
+    getRegistrationsForCrn.mockResolvedValue({
+      status: 200,
+      response: {
         mappa: {
           level: 'M1',
           levelDescription: 'MAPPA Level 1',
@@ -64,7 +64,7 @@ describe('GetRegistrations', () => {
         },
         flags: [],
       },
-    ])
+    })
 
     const registrations = await getRegistrations('A123456', user)
 
@@ -79,9 +79,9 @@ describe('GetRegistrations', () => {
   })
 
   it('handles when there is no MAPPA level', async () => {
-    getRegistrationsForCrn.mockResolvedValue([
-      true,
-      {
+    getRegistrationsForCrn.mockResolvedValue({
+      status: 200,
+      response: {
         mappa: {
           category: 'M2',
           categoryDescription: 'MAPPA Cat 2',
@@ -89,7 +89,7 @@ describe('GetRegistrations', () => {
         },
         flags: [],
       },
-    ])
+    })
 
     const registrations = await getRegistrations('A123456', user)
 
@@ -104,9 +104,9 @@ describe('GetRegistrations', () => {
   })
 
   it('handles when there is no MAPPA startDate', async () => {
-    getRegistrationsForCrn.mockResolvedValue([
-      true,
-      {
+    getRegistrationsForCrn.mockResolvedValue({
+      status: 200,
+      response: {
         mappa: {
           level: 'M1',
           levelDescription: 'MAPPA Level 1',
@@ -115,7 +115,7 @@ describe('GetRegistrations', () => {
         },
         flags: [],
       },
-    ])
+    })
 
     const registrations = await getRegistrations('A123456', user)
 
@@ -130,12 +130,12 @@ describe('GetRegistrations', () => {
   })
 
   it('returns risk flags', async () => {
-    getRegistrationsForCrn.mockResolvedValue([
-      true,
-      {
+    getRegistrationsForCrn.mockResolvedValue({
+      status: 200,
+      response: {
         flags: [{ code: 'IRMO', description: 'Hate Crime', colour: 'Red' }],
       },
-    ])
+    })
 
     const registrations = await getRegistrations('A123456', user)
 
@@ -150,12 +150,12 @@ describe('GetRegistrations', () => {
   })
 
   it('handles when there are no risk flags', async () => {
-    getRegistrationsForCrn.mockResolvedValue([
-      true,
-      {
+    getRegistrationsForCrn.mockResolvedValue({
+      status: 200,
+      response: {
         flags: [],
       },
-    ])
+    })
 
     const registrations = await getRegistrations('A123456', user)
 
@@ -167,6 +167,40 @@ describe('GetRegistrations', () => {
         lastUpdated: null,
       },
     })
+  })
+
+  it('flags when the response is 404', async () => {
+    getRegistrationsForCrn.mockResolvedValue({
+      status: 404,
+      ok: false,
+      response: {},
+    })
+
+    const registrations = await getRegistrations('A123456', user)
+
+    expect(registrations).toEqual({
+      flags: [],
+      mappa: {},
+    })
+  })
+
+  it('returns null when there is a failed request', async () => {
+    await Promise.all(
+      [400, 401, 403, 500, 501, 502, 503, 504].map(async statusCode => {
+        getRegistrationsForCrn.mockResolvedValue({
+          status: statusCode,
+          ok: false,
+          response: {},
+        })
+
+        const registrations = await getRegistrations('A123456', user)
+
+        expect(registrations).toEqual({
+          flags: null,
+          mappa: null,
+        })
+      }),
+    )
   })
 })
 

--- a/app/upw/controllers/common.utils.test.js
+++ b/app/upw/controllers/common.utils.test.js
@@ -172,9 +172,10 @@ describe('GetRegistrations', () => {
 
 describe('GetRegistrations', () => {
   it('returns ROSH risk data', async () => {
-    getRoshRiskSummaryForCrn.mockResolvedValue([
-      true,
-      {
+    getRoshRiskSummaryForCrn.mockResolvedValue({
+      status: 200,
+      ok: true,
+      response: {
         overallRisk: 'HIGH',
         riskToChildrenInCommunity: 'LOW',
         riskToPublicInCommunity: 'HIGH',
@@ -182,12 +183,13 @@ describe('GetRegistrations', () => {
         riskToStaffInCommunity: 'HIGH',
         lastUpdated: '2021-10-10',
       },
-    ])
+    })
 
     const riskSummary = await getRoshRiskSummary('A123456', user)
 
     expect(riskSummary).toEqual({
       roshRiskSummary: {
+        hasBeenCompleted: true,
         lastUpdated: '10th October 2021',
         overallRisk: 'HIGH',
         riskToChildren: 'LOW',
@@ -199,9 +201,10 @@ describe('GetRegistrations', () => {
   })
 
   it('returns null when "NOT_KNOWN" risk', async () => {
-    getRoshRiskSummaryForCrn.mockResolvedValue([
-      true,
-      {
+    getRoshRiskSummaryForCrn.mockResolvedValue({
+      status: 200,
+      ok: true,
+      response: {
         overallRisk: 'NOT_KNOWN',
         riskToChildrenInCommunity: 'NOT_KNOWN',
         riskToPublicInCommunity: 'NOT_KNOWN',
@@ -209,12 +212,13 @@ describe('GetRegistrations', () => {
         riskToStaffInCommunity: 'NOT_KNOWN',
         lastUpdated: '2021-10-10',
       },
-    ])
+    })
 
     const riskSummary = await getRoshRiskSummary('A123456', user)
 
     expect(riskSummary).toEqual({
       roshRiskSummary: {
+        hasBeenCompleted: true,
         lastUpdated: '10th October 2021',
         overallRisk: null,
         riskToChildren: null,

--- a/app/upw/controllers/common.utils.test.js
+++ b/app/upw/controllers/common.utils.test.js
@@ -228,4 +228,38 @@ describe('GetRegistrations', () => {
       },
     })
   })
+
+  it('flags as notBeenCompleted when the response is 404', async () => {
+    getRoshRiskSummaryForCrn.mockResolvedValue({
+      status: 404,
+      ok: false,
+      response: {},
+    })
+
+    const riskSummary = await getRoshRiskSummary('A123456', user)
+
+    expect(riskSummary).toEqual({
+      roshRiskSummary: {
+        hasBeenCompleted: false,
+      },
+    })
+  })
+
+  it('returns null when the response is 400', async () => {
+    await Promise.all(
+      [400, 401, 403, 500, 501, 502, 503, 504].map(async statusCode => {
+        getRoshRiskSummaryForCrn.mockResolvedValue({
+          status: statusCode,
+          ok: false,
+          response: {},
+        })
+
+        const riskSummary = await getRoshRiskSummary('A123456', user)
+
+        expect(riskSummary).toEqual({
+          roshRiskSummary: null,
+        })
+      }),
+    )
+  })
 })

--- a/app/upw/controllers/saveAndContinue.js
+++ b/app/upw/controllers/saveAndContinue.js
@@ -29,15 +29,15 @@ const invalidateDeclarations = removeAnswers(['declaration'])
 class SaveAndContinue extends BaseSaveAndContinue {
   async locals(req, res, next) {
     const deliusRegistrations = await getRegistrations(req.session.assessment?.subject?.crn, req.user)
-    const roshRiskSummary = await getRoshRiskSummary(req.session.assessment?.subject?.crn, req.user)
+    const { roshRiskSummary } = await getRoshRiskSummary(req.session.assessment?.subject?.crn, req.user)
 
-    if (roshRiskSummary.roshRiskSummary === null || roshRiskSummary.roshRiskSummary?.overallRisk === null) {
+    if (roshRiskSummary?.hasBeenCompleted === false) {
       trackEvent(EVENTS.ARN_NO_ROSH_DATA_AVAILABLE, req)
     }
 
     res.locals.widgetData = {
       ...deliusRegistrations,
-      ...roshRiskSummary,
+      roshRiskSummary,
     }
 
     await super.locals(req, res, next)

--- a/common/data/hmppsAssessmentApi.js
+++ b/common/data/hmppsAssessmentApi.js
@@ -125,11 +125,30 @@ const getRegistrationsForCrn = (crn, authorisationToken, userId) => {
   return action(superagent.get(path), authorisationToken, userId)
 }
 
-const getRoshRiskSummaryForCrn = (crn, authorisationToken, userId) => {
-  const path = `${url}/assessments/${crn}/ROSH/summary`
-  logger.info(`Calling hmppsAssessments API with GET: ${path}`)
+const getRoshRiskSummaryForCrn = async (crn, user) => {
+  const endpoint = `${url}/assessments/${crn}/ROSH/summary`
 
-  return action(superagent.get(path), authorisationToken, userId)
+  if (user.token === undefined) {
+    throw new Error('No authorisation token found when calling hmppsAssessments API')
+  }
+
+  logger.info(`Calling hmppsAssessments API with GET: ${endpoint}`)
+
+  const userDetails = await getCachedUserDetails(user.id)
+
+  try {
+    return await superagent
+      .get(endpoint)
+      .auth(user.token, { type: 'bearer' })
+      .set('x-correlation-id', getCorrelationId())
+      .set('x-user-area', userDetails?.areaCode || '')
+      .accept('application/json')
+      .then(({ ok, body, status }) => ({ ok, response: body, status }))
+  } catch (e) {
+    logError(e)
+    const { response, status } = e
+    return { ok: false, response, status }
+  }
 }
 
 const getFilteredReferenceData = (assessmentId, episodeId, questionCode, parentList, authorisationToken, userId) => {

--- a/common/templates/components/mappa-widget/macro.njk
+++ b/common/templates/components/mappa-widget/macro.njk
@@ -1,3 +1,3 @@
-{% macro mappaWidget(params) %}
+{% macro mappaWidget(mappa) %}
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/common/templates/components/mappa-widget/template.njk
+++ b/common/templates/components/mappa-widget/template.njk
@@ -10,6 +10,6 @@
     <h3 class="govuk-heading-m"><strong>UNKNOWN</strong> MAPPA</h3>
     <p class="govuk-body-m">Multi-agency public protection arrangements</p>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-    <p class="govuk-body-m">Something went wrong, we are unable to show MAPPA information at this time.</p>
+    <p class="govuk-body-m">Something went wrong. We are unable to show MAPPA information at this time. Try again later.</p>
 {% endif %}
 </div>

--- a/common/templates/components/mappa-widget/template.njk
+++ b/common/templates/components/mappa-widget/template.njk
@@ -1,5 +1,15 @@
 <div class="mappa-widget">
-    <h3 class="govuk-heading-m"><strong>{{ params.level | default("NO", true) }}</strong> MAPPA</h3>
+{% if mappa != null %}
+    <h3 class="govuk-heading-m"><strong>{{ mappa.level | default("NO", true) }}</strong> MAPPA</h3>
     <p class="govuk-body-m">Multi-agency public protection arrangements</p>
-    {% if params.level %}<p class="govuk-hint govuk-body-m">Last updated: {{ params.lastUpdated | default("Not known") }}</p>{% endif %}
+    {% if mappa.level and mappa.lastUpdated %}
+        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+        <p class="govuk-hint govuk-body-m">Last updated: {{ mappa.lastUpdated }}</p>
+    {% endif %}
+{% else %}
+    <h3 class="govuk-heading-m"><strong>UNKNOWN</strong> MAPPA</h3>
+    <p class="govuk-body-m">Multi-agency public protection arrangements</p>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+    <p class="govuk-body-m">Something went wrong, we are unable to show MAPPA information at this time.</p>
+{% endif %}
 </div>

--- a/common/templates/components/risk-flag-widget/template.njk
+++ b/common/templates/components/risk-flag-widget/template.njk
@@ -12,6 +12,6 @@
             <p>No risks</p>
         {% endif %}
     {% else %}
-        <p>Something went wrong, we are unable to show risk flags at this time.</p>
+        <p>Something went wrong. We are unable to show risk flags at this time. Try again later.</p>
     {% endif %}
 </div>

--- a/common/templates/components/risk-flag-widget/template.njk
+++ b/common/templates/components/risk-flag-widget/template.njk
@@ -1,13 +1,17 @@
 <div class="risk-flag-widget">
     <h3 class="govuk-heading-m">Delius risk flags (registers)</h3>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-    {% if flags %}
-    <ul class="govuk-list">
-    {% for risk in flags %}
-        <li>{{ risk }}</li>
-    {% endfor %}
-    </ul>
+    {% if flags != null %}
+        {% if flags.length %}
+            <ul class="govuk-list">
+            {% for risk in flags %}
+                <li>{{ risk }}</li>
+            {% endfor %}
+            </ul>
+        {% else %}
+            <p>No risks</p>
+        {% endif %}
     {% else %}
-    <p>No risks</p>
+        <p>Something went wrong, we are unable to show risk flags at this time.</p>
     {% endif %}
 </div>

--- a/common/templates/components/rosh-widget/macro.njk
+++ b/common/templates/components/rosh-widget/macro.njk
@@ -1,3 +1,3 @@
-{% macro roshWidget(params) %}
+{% macro roshWidget(roshSummary) %}
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/common/templates/components/rosh-widget/template.njk
+++ b/common/templates/components/rosh-widget/template.njk
@@ -34,11 +34,11 @@ rosh-widget__risk--low
 {% endif %}
 {% endmacro %}
 
-{% if params and params.overallRisk %}
-<div class="rosh-widget {{ getOverallRiskLevelClass(params.overallRisk) }}">
-    <h3 class="govuk-heading-m"><strong>{{ getRiskLevelText(params.overallRisk) | upper }}</strong> RoSH</h3>
+{% if roshSummary and roshSummary.hasBeenCompleted %}
+<div class="rosh-widget {{ getOverallRiskLevelClass(roshSummary.overallRisk) }}">
+    <h3 class="govuk-heading-m"><strong>{{ getRiskLevelText(roshSummary.overallRisk) | upper }}</strong> RoSH</h3>
     <p class="govuk-body-m">Risk of serious harm</p>
-    <p class="govuk-hint govuk-body-m">Last updated: {{ params.lastUpdated | default("Not known") }}</p>
+    <p class="govuk-hint govuk-body-m">Last updated: {{ roshSummary.lastUpdated | default("Not known") }}</p>
 
     <table class="govuk-table rosh-widget__table">
         <thead class="govuk-table__head">
@@ -50,27 +50,33 @@ rosh-widget__risk--low
         <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
                 <th class="govuk-table__header">Children</th>
-                <td class="govuk-table__cell {{ getRiskLevelClass(params.riskToChildren) }}">{{ getRiskLevelText(params.riskToChildren) | default("No data") }}</td>
+                <td class="govuk-table__cell {{ getRiskLevelClass(roshSummary.riskToChildren) }}">{{ getRiskLevelText(roshSummary.riskToChildren) | default("No data") }}</td>
             </tr>
             <tr>
                 <th class="govuk-table__header">Public</th>
-                <td class="govuk-table__cell {{ getRiskLevelClass(params.riskToPublic) }}">{{ getRiskLevelText(params.riskToPublic) | default("No data") }}</td>
+                <td class="govuk-table__cell {{ getRiskLevelClass(roshSummary.riskToPublic) }}">{{ getRiskLevelText(roshSummary.riskToPublic) | default("No data") }}</td>
             </tr>
             <tr>
                 <th class="govuk-table__header">Known adult</th>
-                <td class="govuk-table__cell {{ getRiskLevelClass(params.riskToKnownAdult) }}">{{ getRiskLevelText(params.riskToKnownAdult) | default("No data") }}</td>
+                <td class="govuk-table__cell {{ getRiskLevelClass(roshSummary.riskToKnownAdult) }}">{{ getRiskLevelText(roshSummary.riskToKnownAdult) | default("No data") }}</td>
             </tr>
             <tr>
                 <th class="govuk-table__header">Staff</th>
-                <td class="govuk-table__cell {{ getRiskLevelClass(params.riskToStaff) }}">{{ getRiskLevelText(params.riskToStaff) | default("No data") }}</td>
+                <td class="govuk-table__cell {{ getRiskLevelClass(roshSummary.riskToStaff) }}">{{ getRiskLevelText(roshSummary.riskToStaff) | default("No data") }}</td>
             </tr>
         </tbody>
     </table>
 </div>
-{% else %}
+{% elif roshSummary and not roshSummary.hasBeenCompleted %}
 <div class="rosh-widget {{ roshWidgetClass }}">
-    <h3 class="govuk-heading-m"><strong>NO LEVEL</strong> RoSH</h3>
+    <h3 class="govuk-heading-m"><strong>NO</strong> RoSH</h3>
     <p class="govuk-body-m">Risk of serious harm</p>
     <p class="govuk-hint govuk-body-m">A RoSH summary has not been completed for this individual.</p>
+</div>
+{% else %}
+<div class="rosh-widget {{ roshWidgetClass }}">
+    <h3 class="govuk-heading-m"><strong>UNKNOWN</strong> RoSH</h3>
+    <p class="govuk-body-m">Risk of serious harm</p>
+    <p class="govuk-hint govuk-body-m">Something went wrong, we are unable to show RoSH data at this time.</p>
 </div>
 {% endif %}

--- a/common/templates/components/rosh-widget/template.njk
+++ b/common/templates/components/rosh-widget/template.njk
@@ -77,6 +77,6 @@ rosh-widget__risk--low
 <div class="rosh-widget {{ roshWidgetClass }}">
     <h3 class="govuk-heading-m"><strong>UNKNOWN</strong> RoSH</h3>
     <p class="govuk-body-m">Risk of serious harm</p>
-    <p class="govuk-hint govuk-body-m">Something went wrong, we are unable to show RoSH data at this time.</p>
+    <p class="govuk-hint govuk-body-m">Something went wrong. We are unable to show RoSH information at this time. Try again later.</p>
 </div>
 {% endif %}


### PR DESCRIPTION
This PR aims to provide better handling for the RoSH, MAPPA and Flags widgets in the UPW workflow, a few considerations:

- Graceful handling when unable to fetch data, we don't want to prevent use of the rest of the application
- `200` status codes should display and where specific information is unavailable show an appropriate tag
- `404` status codes imply that there is no matching information for the given CRN, we should notify the user in the widget
- Other status codes `400` and above would indicate there is an issue preventing us fetching the data, again we should notify the user in the widget

**RoSH: Everything is fine**
<img width="307" alt="Screenshot 2022-05-05 at 14 41 26" src="https://user-images.githubusercontent.com/20080441/166941720-52530901-95ac-4290-8151-d5828cce32af.png">

**RoSH: No matching RoSH summary for the given CRN**
<img width="306" alt="Screenshot 2022-05-05 at 14 35 46" src="https://user-images.githubusercontent.com/20080441/166941775-d1f6c30f-6df4-4d04-9707-aeb90f559dc7.png">

**RoSH: Something went wrong**
<img width="309" alt="Screenshot 2022-05-05 at 14 37 12" src="https://user-images.githubusercontent.com/20080441/166941838-776b2973-93de-4c12-91f8-dc8c30f41b94.png">

**MAPPA/Flags: Everything is fine**
<img width="302" alt="Screenshot 2022-05-06 at 13 57 34" src="https://user-images.githubusercontent.com/20080441/167136662-d7282439-1510-49f1-8f09-f70e827e261e.png">

**MAPPA/Flags: No matching registrations for the given CRN**
<img width="307" alt="Screenshot 2022-05-06 at 13 58 30" src="https://user-images.githubusercontent.com/20080441/167136710-cb09a2d9-5d7e-4065-9f27-ba7138d8767f.png">

**MAPPA/Flags: Something went wrong**
<img width="309" alt="Screenshot 2022-05-06 at 13 59 23" src="https://user-images.githubusercontent.com/20080441/167136756-83d37fa6-dab4-4474-9a2c-3baa80e96192.png">

Content and design are subject to change