### PR TITLE
Add flag to expose request ID on error pages for debugging

### DIFF
--- a/app/error.njk
+++ b/app/error.njk
@@ -17,9 +17,15 @@
         {{ heading | default("There is a problem with the service") }}
       </h1>
       {% if subHeading %}
-      <h2 class="govuk-heading-m">
-        {{ subHeading }}
-      </h2>
+        <h2 class="govuk-heading-m">
+          {{ subHeading }}
+        </h2>
+        {% if showRequestIdOnErrorPage and correlationId %}
+          <div class="govuk-inset-text">
+            <span><p class="govuk-body"><strong>Request ID:</strong> {{ correlationId }}</p></span>
+            <p class="govuk-body">Please supply this ID when reporting the issue above.</p>
+          </div>
+        {%endif%}
       {% endif %}
       {% if showDetailedErrors %}
         {% if error %}

--- a/app/router.js
+++ b/app/router.js
@@ -61,6 +61,7 @@ const upwWorkflow = require('./upw')
 
 const logger = require('../common/logging/logger')
 const { verifyAssessment } = require('./startAssessment/get.controller')
+const { getCorrelationId } = require('../common/utils/util')
 
 const assessmentUrl = `/${devAssessmentId}/questiongroup/ROSH/summary`
 
@@ -205,6 +206,7 @@ module.exports = app => {
 
   app.use((error, req, res, next) => {
     logger.info(`Unhandled exception received - ${error.message} ${error.stack}`)
+    res.locals.correlationId = getCorrelationId()
     res.render('app/error', {
       subHeading: 'Something unexpected happened',
       error,

--- a/helm_deploy/hmpps-risk-assessment-ui/templates/_envs.tpl
+++ b/helm_deploy/hmpps-risk-assessment-ui/templates/_envs.tpl
@@ -67,6 +67,9 @@ env:
   - name: SHOW_DETAILED_ERRORS
     value: {{ .Values.env.SHOW_DETAILED_ERRORS | quote }}
 
+  - name: SHOW_REQUEST_ID_ON_ERROR_PAGE
+    value: {{ .Values.env.SHOW_REQUEST_ID_ON_ERROR_PAGE | quote }}
+
   - name: PDF_CONVERTER_ENDPOINT
     value: {{ .Values.env.PDF_CONVERTER_ENDPOINT | quote }}
 

--- a/helm_deploy/values-development.yaml
+++ b/helm_deploy/values-development.yaml
@@ -34,6 +34,7 @@ env:
   OAUTH_ENDPOINT_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
   PDF_CONVERTER_ENDPOINT: http://hmpps-risk-assessment-ui-gotenberg.hmpps-assessments-dev.svc.cluster.local/forms/chromium/convert/html
   SHOW_DETAILED_ERRORS: true
+  SHOW_REQUEST_ID_ON_ERROR_PAGE: true
   DEV_ASSESSMENT_ID: "fb6b7c33-07fc-4c4c-a009-8d60f66952c4"
 
 allow_list:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -34,6 +34,7 @@ env:
   OAUTH_ENDPOINT_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
   PDF_CONVERTER_ENDPOINT: http://hmpps-risk-assessment-ui-gotenberg.hmpps-assessments-preprod.svc.cluster.local/forms/chromium/convert/html
   SHOW_DETAILED_ERRORS: false
+  SHOW_REQUEST_ID_ON_ERROR_PAGE: false
   DEV_ASSESSMENT_ID: "fb6b7c33-07fc-4c4c-a009-8d60f66952c4"
 
 allow_list:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -34,6 +34,7 @@ env:
   OAUTH_ENDPOINT_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
   PDF_CONVERTER_ENDPOINT: http://hmpps-risk-assessment-ui-gotenberg.hmpps-assessments-prod.svc.cluster.local/forms/chromium/convert/html
   SHOW_DETAILED_ERRORS: false
+  SHOW_REQUEST_ID_ON_ERROR_PAGE: false
   DEV_ASSESSMENT_ID: "fb6b7c33-07fc-4c4c-a009-8d60f66952c4"
 
 allow_list:

--- a/server.js
+++ b/server.js
@@ -103,6 +103,7 @@ function initialiseGlobalMiddleware(app) {
   app.use((req, res, next) => {
     res.locals.asset_path = '/public/' // eslint-disable-line camelcase
     res.locals.showDetailedErrors = process.env.SHOW_DETAILED_ERRORS === 'true'
+    res.locals.showRequestIdOnErrorPage = process.env.SHOW_REQUEST_ID_ON_ERROR_PAGE === 'true'
     noCache(res)
     next()
   })


### PR DESCRIPTION
This PR aims to allow testing to provide the Correlation ID when experiencing failures in `dev` this should in **theory** allow us to trace the exact request across our backend services and gain a full picture of what went wrong