### PR TITLE
Update SaveAndContinue controller to store rawAnswers after fetching

### DIFF
--- a/app/common/controllers/saveAndContinue.js
+++ b/app/common/controllers/saveAndContinue.js
@@ -107,9 +107,8 @@ class SaveAndContinue extends BaseController {
     if (res.locals.questionGroupCode && res.locals.addingNewMultiple && errorSummary.length === 0) {
       res.locals.clearQuestionAnswers = true
     }
-    if (res.locals.questionGroupCode) {
-      req.sessionModel.set('rawAnswers', { ...previousAnswers, ...answerDtoFrom(submittedAnswers) })
-    }
+
+    req.sessionModel.set('rawAnswers', { ...previousAnswers, ...answerDtoFrom(submittedAnswers) })
     req.sessionModel.set('errors', {})
 
     const submittedErrors = res.locals.errors || {}

--- a/app/upw/controllers/gpDetailsSaveAndContinue.js
+++ b/app/upw/controllers/gpDetailsSaveAndContinue.js
@@ -20,7 +20,7 @@ const customValidationsGpDetails = (fields, gpDetails, gpDetailsComplete) => {
 class SaveAndContinue extends upwSaveAndContinue {
   async validateFields(req, res, next) {
     // make changes to sessionModel fields to add in context specific validations
-    const { gp_details = [] } = req.sessionModel.get('rawAnswers') || []
+    const { gp_details = [] } = req.sessionModel.get('rawAnswers') || {}
 
     const { gp_details_complete = '' } = req.form.values
 

--- a/app/upw/controllers/individualsDetailsSaveAndContinue.js
+++ b/app/upw/controllers/individualsDetailsSaveAndContinue.js
@@ -20,7 +20,7 @@ const customValidationsIndividualsDetails = (fields, emergencyContacts, individu
 class SaveAndContinue extends upwSaveAndContinue {
   async validateFields(req, res, next) {
     // make changes to sessionModel fields to add in context specific validations
-    const { emergency_contact_details = [] } = req.sessionModel.get('rawAnswers') || []
+    const { emergency_contact_details = [] } = req.sessionModel.get('rawAnswers') || {}
 
     const { individual_details_complete = '' } = req.form.values
 


### PR DESCRIPTION
Updated the `SaveAndContinue` controller to set `rawAnswers` after fetching answers from the backend by default. We were attempting to access these when validating certain pages and they were unset, so hopefully this fixes the issues we were seeing around this