### PR TITLE
Fix 'declined' checkbox autoselecting for GP and EC pages

### DIFF
--- a/app/upw/templates/individuals-details/individuals-details.njk
+++ b/app/upw/templates/individuals-details/individuals-details.njk
@@ -168,7 +168,7 @@
                     {
                         value: "declined",
                         text: "Individual declined to give an emergency contact",
-                        checked: rawAnswers['emergency_contact_declined']
+                        checked: rawAnswers['emergency_contact_declined'] | hasAnswer("declined")
                     }
                 ]
             }) }}

--- a/app/upw/templates/placement-restrictions/gp-details.njk
+++ b/app/upw/templates/placement-restrictions/gp-details.njk
@@ -103,7 +103,7 @@
                         {
                             value: "declined",
                             text: "Individual declined to give GP details",
-                            checked: rawAnswers['gp_details_declined']
+                            checked: rawAnswers['gp_details_declined'] | hasAnswer("declined")
                         }
                     ]
                 }) }}

--- a/server.js
+++ b/server.js
@@ -167,6 +167,7 @@ function initialiseTemplateEngine(app) {
   nunjucksEnvironment.addFilter('prettyDateAndTime', prettyDateAndTime)
   nunjucksEnvironment.addFilter('ageFrom', ageFrom)
   nunjucksEnvironment.addFilter('clearAnswers', clearAnswers)
+  nunjucksEnvironment.addFilter('hasAnswer', (a, v) => a.includes(v))
 
   // for textarea or input components we can add an extra filter to encode any raw HTML characters
   // that might cause security issues otherwise


### PR DESCRIPTION
The `Individual declined to give an emergency contact` question was autoselecting on the `Individuals Details` and `GP Details` pages, I've updated the templates so that we're passing a `boolean` to the `checked` attribute for the checkbox group