### PR TITLE
Add missing field to GP Details step definition

### DIFF
--- a/app/upw/steps.js
+++ b/app/upw/steps.js
@@ -203,7 +203,7 @@ module.exports = {
     controller: gpDetailsSaveAndContinue,
     template: `${__dirname}/templates/placement-restrictions/gp-details.njk`,
     next: 'task-list#gp-details',
-    fields: ['gp_details_complete'],
+    fields: ['gp_details_complete', 'gp_details_declined'],
   },
   '/edit-gp-details/*': {
     pageTitle: 'Details of GP',


### PR DESCRIPTION
`gp_details_declined` was missing from the `gp-details` step definition, this was causing validation not to run correctly and data not being persisted for this field