### PR TITLE
Update styling for Low/No RoSH states

### DIFF
--- a/common/assets/sass/_widgets.scss
+++ b/common/assets/sass/_widgets.scss
@@ -9,6 +9,7 @@ $high-score-colour: #942514;
 $high-score-border-colour: #d4351c;
 $very-high-score-colour: #711a0d;
 $very-high-score-border-colour: #942514;
+$unknown-score-border-colour: #fd0;
 $mappa-colour: #4c2c92;
 
 .rosh-widget {
@@ -20,6 +21,10 @@ $mappa-colour: #4c2c92;
     margin-bottom: govuk-spacing(1);
     font-weight: 400;
   }
+}
+
+.rosh-widget--unknown {
+  border: 2px solid $unknown-score-border-colour;
 }
 
 .rosh-widget--low {

--- a/common/templates/components/rosh-widget/template.njk
+++ b/common/templates/components/rosh-widget/template.njk
@@ -70,14 +70,14 @@ rosh-widget__risk--low
     </table>
 </div>
 {% elif roshSummary and not roshSummary.hasBeenCompleted %}
-<div class="rosh-widget {{ roshWidgetClass }}">
-    <h3 class="govuk-heading-m"><strong>NO</strong> RoSH</h3>
+<div class="rosh-widget rosh-widget--unknown">
+    <h3 class="govuk-heading-m"><strong>UNKNOWN LEVEL</strong> RoSH</h3>
     <p class="govuk-body-m">Risk of serious harm</p>
-    <p class="govuk-hint govuk-body-m">A RoSH summary has not been completed for this individual.</p>
+    <p class="govuk-hint govuk-body-m">A RoSH summary has not been completed for this individual. Check OASys for this persons current assessment status.</p>
 </div>
 {% else %}
-<div class="rosh-widget {{ roshWidgetClass }}">
-    <h3 class="govuk-heading-m"><strong>UNKNOWN</strong> RoSH</h3>
+<div class="rosh-widget">
+    <h3 class="govuk-heading-m"><strong>UNKNOWN LEVEL</strong> RoSH</h3>
     <p class="govuk-body-m">Risk of serious harm</p>
     <p class="govuk-hint govuk-body-m">Something went wrong. We are unable to show RoSH information at this time. Try again later.</p>
 </div>


### PR DESCRIPTION
This PR updates the Low/No RoSH widgets to include the updated styling and content changes in ARN-1003

Low/No RoSH:
<img width="295" alt="Screenshot 2022-06-10 at 11 48 44" src="https://user-images.githubusercontent.com/20080441/173049854-d877daad-f3bc-48b8-a362-7a0ff2e8c925.png">
