### PR TITLE
Remove unused field from UPW PDF template

### DIFF
--- a/app/upw/fields.js
+++ b/app/upw/fields.js
@@ -205,9 +205,6 @@ const fields = {
     dependent: { field: 'placement_preference', value: 'YES' },
     ...requireSelectOption,
   },
-  placement_preference_by_gender_details: {
-    ...requireEnterDetails,
-  },
   history_sexual_offending: {
     validate: [
       {

--- a/app/upw/templates/pdf-preview-and-declaration/components/pdf-template/template.njk
+++ b/app/upw/templates/pdf-preview-and-declaration/components/pdf-template/template.njk
@@ -377,12 +377,6 @@
                     heading: "Does the individual have any placement preferences?",
                     condition: showPlacementPreferences,
                     data: renderValue(answers["placement_preferences"])
-                },
-                {
-                    heading: "Discuss placement options with the individual, based on their gender identity",
-                    description: "Record their preference and the details of the conversation.",
-                    condition: showPlacementPreferencesByGender,
-                    data: renderValue(answers["placement_preference_by_gender_details"])
                 }
             ]
         }) }}


### PR DESCRIPTION
Removing the `placement_preference_by_gender_details` field from the `Diversity` section of the UPW PDF template.
This field was removed in `v4` of the UPW PDF and this field looks to be unused in the application.