### PR TITLE
1052 availability default to no ticks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,14 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+export NVM_DIR="$HOME/.nvm/nvm.sh"
+. "$(dirname $NVM_DIR)/nvm.sh"
+
+export NVM_DIR="$HOME/.nvm"
+a=$(nvm ls | grep 'node')
+b=${a#*(-> }
+v=${b%%[)| ]*}
+
+export PATH="$NVM_DIR/versions/node/$v/bin:$PATH"
 
 npx lint-staged && npm test

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,14 +1,7 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-export NVM_DIR="$HOME/.nvm/nvm.sh"
-. "$(dirname $NVM_DIR)/nvm.sh"
-
 export NVM_DIR="$HOME/.nvm"
-a=$(nvm ls | grep 'node')
-b=${a#*(-> }
-v=${b%%[)| ]*}
-
-export PATH="$NVM_DIR/versions/node/$v/bin:$PATH"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 
 npx lint-staged && npm test

--- a/app/upw/templates/placement-details/availability.njk
+++ b/app/upw/templates/placement-details/availability.njk
@@ -7,119 +7,140 @@
 {% set backLink = 'task-list' %}
 
 {% block pageTitle %}
-{{ pageTitle }}
+  {{ pageTitle }}
 {% endblock %}
 
 {% block header %}
-{% include "common/templates/partials/header.njk" %}
+  {% include "common/templates/partials/header.njk" %}
 {% endblock %}
 
 {% block content %}
-{# include errorSummary partial #}
-{{ super() }}
+  {# include errorSummary partial #}
+  {{ super() }}
 
-{%- macro getAvailabilityValue(index) -%}
+  {%- macro getAvailabilityValue(index) -%}
     {{ questions['individual_availability'].answerDtos[index].value }}
-{%- endmacro -%}
+  {%- endmacro -%}
 
-{%- macro getAvailabilityText(index) -%}
+  {%- macro getAvailabilityText(index) -%}
     {{ questions['individual_availability'].answerDtos[index].text }}
-{%- endmacro -%}
+  {%- endmacro -%}
 
-{%- macro getAvailabilityChecked(index) -%}
-    {%- if questions['individual_availability'].answer == "" -%}checked{%- elseif questions['individual_availability'].answerDtos[index].checked == true -%}
-        checked
+  {%- macro getAvailabilityChecked(index) -%}
+    {%- if questions['individual_availability'].answerDtos[index].checked == true -%}
+      checked
     {%- endif -%}
-{%- endmacro -%}
+  {%- endmacro -%}
 
-{%- macro availabilityOption(optionNumber) -%}
+  {%- macro availabilityOption(optionNumber) -%}
     <td class="govuk-table__cell upw-availability-table__column upw-availability-table__item-{{ optionNumber }}">
-        <div class="govuk-checkboxes__item govuk-checkboxes govuk-checkboxes--small upw-checkbox-item__availability">
-            <input class="govuk-checkboxes__input" name="{{ questions['individual_availability'].questionCode }}" id="{{ questions['individual_availability'].questionCode }}-{{ optionNumber}}" name="organisation" type="checkbox" value="{{ getAvailabilityValue(optionNumber) }}" {{ getAvailabilityChecked(optionNumber) }}>
-            <label class="govuk-label govuk-checkboxes__label" for="{{ questions['individual_availability'].questionCode }}-{{ optionNumber }}"><span class='govuk-visually-hidden'>{{ getAvailabilityText(optionNumber) }}</span></label>
-        </div>
+      <div class="govuk-checkboxes__item govuk-checkboxes govuk-checkboxes--small upw-checkbox-item__availability">
+        <input class="govuk-checkboxes__input" name="{{ questions['individual_availability'].questionCode }}"
+               id="{{ questions['individual_availability'].questionCode }}-{{ optionNumber }}" name="organisation"
+               type="checkbox"
+               value="{{ getAvailabilityValue(optionNumber) }}" {{ getAvailabilityChecked(optionNumber) }}>
+        <label class="govuk-label govuk-checkboxes__label"
+               for="{{ questions['individual_availability'].questionCode }}-{{ optionNumber }}"><span
+              class='govuk-visually-hidden'>{{ getAvailabilityText(optionNumber) }}</span></label>
+      </div>
     </td>
-{%- endmacro -%}
+  {%- endmacro -%}
 
-<div class="govuk-grid-row">
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
-        <span class="govuk-caption-xl">Placement details</span>
-        <h1 class="govuk-heading-xl">
-            Availability for Community Payback work
-        </h1>
-        
-        <form method="post" action="{{ action }}">
-            <input type="hidden" name="x-csrf-token" value="{{ csrfToken }}">
+      <span class="govuk-caption-xl">Placement details</span>
+      <h1 class="govuk-heading-xl">
+        Availability for Community Payback work
+      </h1>
+
+      <form method="post" action="{{ action }}">
+        <input type="hidden" name="x-csrf-token" value="{{ csrfToken }}">
 
         <fieldset class="govuk-fieldset" aria-describedby="individual_availability-hint">
-            <legend class="govuk-fieldset__legend individual_availability govuk-label--m">
-                {{ questions['individual_availability'].questionText }}
-            </legend>
+          <legend class="govuk-fieldset__legend individual_availability govuk-label--m">
+            {{ questions['individual_availability'].questionText }}
+          </legend>
 
-            <table class="govuk-table upw-availability-table">
-                <thead class="govuk-table__head">
-                <tr><th scope="row" class="govuk-table__header"></th>
-                    <th scope="col" class="govuk-table__header upw-availability-table__column upw-availability-table__header">Monday</th>
-                    <th scope="col" class="govuk-table__header upw-availability-table__column upw-availability-table__header">Tuesday</th>
-                    <th scope="col" class="govuk-table__header upw-availability-table__column upw-availability-table__header">Wednesday</th>
-                    <th scope="col" class="govuk-table__header upw-availability-table__column upw-availability-table__header">Thursday</th>
-                    <th scope="col" class="govuk-table__header upw-availability-table__column upw-availability-table__header">Friday</th>
-                    <th scope="col" class="govuk-table__header upw-availability-table__column upw-availability-table__header">Saturday</th>
-                    <th scope="col" class="govuk-table__header upw-availability-table__column upw-availability-table__header no-right-border">Sunday</th>
-                </tr>
-                </thead>
-                <tbody class="govuk-table__body">
-                <tr class="govuk-table__row">
-                    <th scope="row" class="govuk-table__header upw-availability-table__rowheader">Morning</th>
-                    {{ availabilityOption(0) }}
-                    {{ availabilityOption(3) }}
-                    {{ availabilityOption(6) }}
-                    {{ availabilityOption(9) }}
-                    {{ availabilityOption(12) }}
-                    {{ availabilityOption(15) }}
-                    {{ availabilityOption(18) }}
+          <table class="govuk-table upw-availability-table">
+            <thead class="govuk-table__head">
+            <tr>
+              <th scope="row" class="govuk-table__header"></th>
+              <th scope="col" class="govuk-table__header upw-availability-table__column upw-availability-table__header">
+                Monday
+              </th>
+              <th scope="col" class="govuk-table__header upw-availability-table__column upw-availability-table__header">
+                Tuesday
+              </th>
+              <th scope="col" class="govuk-table__header upw-availability-table__column upw-availability-table__header">
+                Wednesday
+              </th>
+              <th scope="col" class="govuk-table__header upw-availability-table__column upw-availability-table__header">
+                Thursday
+              </th>
+              <th scope="col" class="govuk-table__header upw-availability-table__column upw-availability-table__header">
+                Friday
+              </th>
+              <th scope="col" class="govuk-table__header upw-availability-table__column upw-availability-table__header">
+                Saturday
+              </th>
+              <th scope="col"
+                  class="govuk-table__header upw-availability-table__column upw-availability-table__header no-right-border">
+                Sunday
+              </th>
+            </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header upw-availability-table__rowheader">Morning</th>
+              {{ availabilityOption(0) }}
+              {{ availabilityOption(3) }}
+              {{ availabilityOption(6) }}
+              {{ availabilityOption(9) }}
+              {{ availabilityOption(12) }}
+              {{ availabilityOption(15) }}
+              {{ availabilityOption(18) }}
 
-                </tr>
-                <tr class="govuk-table__row">
-                    <th scope="row" class="govuk-table__header upw-availability-table__rowheader">Afternoon</th>
-                    {{ availabilityOption(1) }}
-                    {{ availabilityOption(4) }}
-                    {{ availabilityOption(7) }}
-                    {{ availabilityOption(10) }}
-                    {{ availabilityOption(13) }}
-                    {{ availabilityOption(16) }}
-                    {{ availabilityOption(19) }}
-                </tr>
-                <tr class="govuk-table__row">
-                    <th scope="row" class="govuk-table__header upw-availability-table__rowheader">Evening</th>
-                    {{ availabilityOption(2) }}
-                    {{ availabilityOption(5) }}
-                    {{ availabilityOption(8) }}
-                    {{ availabilityOption(11) }}
-                    {{ availabilityOption(14) }}
-                    {{ availabilityOption(17) }}
-                    {{ availabilityOption(20) }}
-                </tr>
-                </tbody>
-            </table>
+            </tr>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header upw-availability-table__rowheader">Afternoon</th>
+              {{ availabilityOption(1) }}
+              {{ availabilityOption(4) }}
+              {{ availabilityOption(7) }}
+              {{ availabilityOption(10) }}
+              {{ availabilityOption(13) }}
+              {{ availabilityOption(16) }}
+              {{ availabilityOption(19) }}
+            </tr>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header upw-availability-table__rowheader">Evening</th>
+              {{ availabilityOption(2) }}
+              {{ availabilityOption(5) }}
+              {{ availabilityOption(8) }}
+              {{ availabilityOption(11) }}
+              {{ availabilityOption(14) }}
+              {{ availabilityOption(17) }}
+              {{ availabilityOption(20) }}
+            </tr>
+            </tbody>
+          </table>
         </fieldset>
 
-{#            {{ renderQuestion(questions['individual_availability'], errors) }}#}
-            {{ renderQuestion(questions['individual_availability_details'], errors) }}
+        {#            {{ renderQuestion(questions['individual_availability'], errors) }} #}
+        {{ renderQuestion(questions['individual_availability_details'], errors) }}
 
-            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible upw-complete-break">
-            {{ renderQuestion(questions['individual_availability_complete'], errors) }}
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible upw-complete-break">
+        {{ renderQuestion(questions['individual_availability_complete'], errors) }}
 
-            <div class="questiongroup-action-buttons">
-                {{ govukButton({
-                    text: buttonText | default('Save'),
-                    classes: 'govuk-!-margin-bottom-3 govuk-!-margin-right-1'
-                }) }}
-            </div>
-        </form>
+        <div class="questiongroup-action-buttons">
+          {{ govukButton({
+            text: buttonText | default('Save'),
+            classes: 'govuk-!-margin-bottom-3 govuk-!-margin-right-1'
+          }) }}
+        </div>
+      </form>
     </div>
     <div class="govuk-grid-column-one-quarter">
-        {{ widgets(widgetData) }}
+      {{ widgets(widgetData) }}
     </div>
-</div>
+  </div>
 {% endblock %}


### PR DESCRIPTION
This PR updates the template for the 'availability' page to default to unchecked for each option.

The relevant line changes to achieve this are in lines 29-33 of `availabiity.njk` - the other changes are all minor automatic formatting changes. 

Also tweaked the Husky config file to fix a bug when committing using a third party tool like Sourcetree or GitHub desktop.