### PR TITLE
Add title to the identiers list in offender-details

### DIFF
--- a/common/templates/partials/offenderDetails.njk
+++ b/common/templates/partials/offenderDetails.njk
@@ -18,9 +18,9 @@
     <section class="key-details-bar" aria-label="Key details">
       <div class="key-details-bar__top-block moj-context-header">
         <div class="column-reversed">
-          <h1 class="key-details-bar__name">{{ subjectName }}</h1>
+          <h2 class="key-details-bar__name">{{ subjectName }}</h2>
           <div>
-            <dl class="key-details-bar__other-details">
+            <dl class="key-details-bar__other-details" title="Identifiers for {{ subjectName }}">
               {% if subjectCrn %}
                 <dt class="govuk-body key-details-bar__divider ">CRN:</dt>
                 <dd class="govuk-body ">{{ subjectCrn }}</dd>

--- a/common/templates/partials/offenderDetails.njk
+++ b/common/templates/partials/offenderDetails.njk
@@ -18,7 +18,7 @@
     <section class="key-details-bar" aria-label="Key details">
       <div class="key-details-bar__top-block moj-context-header">
         <div class="column-reversed">
-          <h2 class="key-details-bar__name">{{ subjectName }}</h2>
+          <h2 class="key-details-bar__name"><span class="govuk-visually-hidden">Key details for </span>{{ subjectName }}</h2>
           <div>
             <dl class="key-details-bar__other-details" title="Identifiers for {{ subjectName }}">
               {% if subjectCrn %}


### PR DESCRIPTION
I've added additional context for screen readers for the individuals name, as for the additional identifiers I've added a title to this section as apposed to adding the individuals name to each element to avoid unnecessary repetition 