### PR TITLE
Update page structure to improve accessibility

### DIFF
--- a/app/upw/templates/diversity-information/cultural-and-religious-adjustments.njk
+++ b/app/upw/templates/diversity-information/cultural-and-religious-adjustments.njk
@@ -19,7 +19,7 @@
 {{ super() }}
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
+    <section class="govuk-grid-column-three-quarters" aria-label="Form content">
         <span class="govuk-caption-xl">Diversity information</span>
         
         <form method="post" action="{{ action }}">
@@ -37,9 +37,9 @@
                 }) }}
             </div>
         </form>
-    </div>
-    <div class="govuk-grid-column-one-quarter">
-        {{ widgets(widgetData) }}
-    </div>
+    </section>
+
+    {{ widgets(widgetData) }}
+    
 </div>
 {% endblock %}

--- a/app/upw/templates/diversity-information/gender-information.njk
+++ b/app/upw/templates/diversity-information/gender-information.njk
@@ -19,7 +19,7 @@
 {{ super() }}
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
+    <section class="govuk-grid-column-three-quarters" aria-label="Form content">
         <span class="govuk-caption-xl">Diversity information</span>
         <h1 class="govuk-heading-xl">
             {{ pageTitle }}
@@ -44,9 +44,9 @@
                 }) }}
             </div>
         </form>
-    </div>
-    <div class="govuk-grid-column-one-quarter">
-        {{ widgets(widgetData) }}
-    </div>
+    </section>
+
+    {{ widgets(widgetData) }}
+    
 </div>
 {% endblock %}

--- a/app/upw/templates/diversity-information/placement-preferences.njk
+++ b/app/upw/templates/diversity-information/placement-preferences.njk
@@ -19,7 +19,7 @@
 {{ super() }}
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
+    <section class="govuk-grid-column-three-quarters" aria-label="Form content">
         <span class="govuk-caption-xl">Diversity information</span>
         
         <form method="post" action="{{ action }}">
@@ -37,9 +37,9 @@
                 }) }}
             </div>
         </form>
-    </div>
-    <div class="govuk-grid-column-one-quarter">
-        {{ widgets(widgetData) }}
-    </div>
+    </section>
+
+    {{ widgets(widgetData) }}
+    
 </div>
 {% endblock %}

--- a/app/upw/templates/employment-education-skills/employment-education-skills.njk
+++ b/app/upw/templates/employment-education-skills/employment-education-skills.njk
@@ -10,45 +10,45 @@
 {% set backLink = 'task-list' %}
 
 {% block pageTitle %}
-{{ pageTitle }}
+    {{ pageTitle }}
 {% endblock %}
 
 {% block header %}
-{% include "common/templates/partials/header.njk" %}
+    {% include "common/templates/partials/header.njk" %}
 {% endblock %}
 
 {% block content %}
-{# include errorSummary partial #}
-{{ super() }}
+    {# include errorSummary partial #}
+    {{ super() }}
 
-<div class="govuk-grid-row">
-        <div class="govuk-grid-column-three-quarters">
-        <span class="govuk-caption-xl">Employment, education and skills information</span>
-        <h1 class="govuk-heading-xl">
-            {{ pageTitle }}
-        </h1>
-        
-        <form method="post" action="{{ action }}">
-            <input type="hidden" name="x-csrf-token" value="{{ csrfToken }}">
+    <div class="govuk-grid-row">
+        <section class="govuk-grid-column-three-quarters" aria-label="Form content">
+            <span class="govuk-caption-xl">Employment, education and skills information</span>
+            <h1 class="govuk-heading-xl">
+                {{ pageTitle }}
+            </h1>
 
-            {{ renderQuestion(questions['employment_education'], errors) }}
-            {{ renderQuestion(questions['reading_writing_difficulties'], errors) }}
-            {{ renderQuestion(questions['work_skills'], errors) }}
-            {{ renderQuestion(questions['future_work_plans'], errors) }}
+            <form method="post" action="{{ action }}">
+                <input type="hidden" name="x-csrf-token" value="{{ csrfToken }}">
 
-            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible upw-complete-break">
-            {{ renderQuestion(questions['employment_education_skills_complete'], errors) }}
+                {{ renderQuestion(questions['employment_education'], errors) }}
+                {{ renderQuestion(questions['reading_writing_difficulties'], errors) }}
+                {{ renderQuestion(questions['work_skills'], errors) }}
+                {{ renderQuestion(questions['future_work_plans'], errors) }}
 
-            <div class="questiongroup-action-buttons">
-                {{ govukButton({
+                <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible upw-complete-break">
+                {{ renderQuestion(questions['employment_education_skills_complete'], errors) }}
+
+                <div class="questiongroup-action-buttons">
+                    {{ govukButton({
                     text: buttonText | default('Save'),
                     classes: 'govuk-!-margin-bottom-3 govuk-!-margin-right-1'
                 }) }}
-            </div>
-        </form>
-    </div>
-    <div class="govuk-grid-column-one-quarter">
+                </div>
+            </form>
+        </section>
+
         {{ widgets(widgetData) }}
+
     </div>
-</div>
 {% endblock %}

--- a/app/upw/templates/employment-education-skills/training-employment-opportunities.njk
+++ b/app/upw/templates/employment-education-skills/training-employment-opportunities.njk
@@ -22,7 +22,7 @@
 {{ super() }}
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
+    <section class="govuk-grid-column-three-quarters" aria-label="Form content">
         <span class="govuk-caption-xl">Employment, education and skills information</span>
         <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
             {{ pageTitle }}
@@ -44,9 +44,9 @@
                 }) }}
             </div>
         </form>
-    </div>
-    <div class="govuk-grid-column-one-quarter">
-        {{ widgets(widgetData) }}
-    </div>
+    </section>
+
+    {{ widgets(widgetData) }}
+    
 </div>
 {% endblock %}

--- a/app/upw/templates/individuals-details/add-emergency-contact.njk
+++ b/app/upw/templates/individuals-details/add-emergency-contact.njk
@@ -20,7 +20,7 @@
 {{ super() }}
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <section class="govuk-grid-column-two-thirds" aria-label="Form content">
         <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
         
         <form method="post" action="{{ action }}">
@@ -49,7 +49,6 @@
                 }) }}
             </div>
         </form>
-
-    </div>
+    </section>
 </div>
 {% endblock %}

--- a/app/upw/templates/individuals-details/edit-contact-details.njk
+++ b/app/upw/templates/individuals-details/edit-contact-details.njk
@@ -20,7 +20,7 @@
 {{ super() }}
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <section class="govuk-grid-column-two-thirds" aria-label="Form content">
         <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
         
         <form method="post" action="{{ action }}">
@@ -78,7 +78,6 @@
                 }) }}
             </div>
         </form>
-
-    </div>
+    </section>
 </div>
 {% endblock %}

--- a/app/upw/templates/individuals-details/edit-emergency-contact-details.njk
+++ b/app/upw/templates/individuals-details/edit-emergency-contact-details.njk
@@ -30,7 +30,7 @@
 {% endif %}
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <section class="govuk-grid-column-two-thirds" aria-label="Form content">
         <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
         
         <form method="post" action="{{ action }}">
@@ -60,7 +60,6 @@
                 }) }}
             </div>
         </form>
-
-    </div>
+    </section>
 </div>
 {% endblock %}

--- a/app/upw/templates/individuals-details/edit-personal-details.njk
+++ b/app/upw/templates/individuals-details/edit-personal-details.njk
@@ -20,7 +20,7 @@
 {{ super() }}
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <section class="govuk-grid-column-two-thirds" aria-label="Form content">
         <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
         
         <form method="post" action="{{ action }}">
@@ -41,7 +41,6 @@
                 }) }}
             </div>
         </form>
-
-    </div>
+    </section>
 </div>
 {% endblock %}

--- a/app/upw/templates/individuals-details/individuals-details.njk
+++ b/app/upw/templates/individuals-details/individuals-details.njk
@@ -46,7 +46,7 @@
 {% endset %}
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
+    <section class="govuk-grid-column-three-quarters" aria-label="Form content">
         <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
 
         <h2 class="govuk-heading-l">Personal details</h2>
@@ -193,9 +193,9 @@
                 }) }}
             </div>
         </form>
-    </div>
-    <div class="govuk-grid-column-one-quarter">
-        {{ widgets(widgetData) }}
-    </div>
+    </section>
+
+    {{ widgets(widgetData) }}
+    
 </div>
 {% endblock %}

--- a/app/upw/templates/placement-details/availability.njk
+++ b/app/upw/templates/placement-details/availability.njk
@@ -47,7 +47,7 @@
   {%- endmacro -%}
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
+    <section class="govuk-grid-column-three-quarters" aria-label="Form content">
       <span class="govuk-caption-xl">Placement details</span>
       <h1 class="govuk-heading-xl">
         Availability for Community Payback work
@@ -139,9 +139,9 @@
           }) }}
         </div>
       </form>
-    </div>
-    <div class="govuk-grid-column-one-quarter">
-      {{ widgets(widgetData) }}
-    </div>
+    </section>
+
+    {{ widgets(widgetData) }}
+    
   </div>
 {% endblock %}

--- a/app/upw/templates/placement-details/equipment.njk
+++ b/app/upw/templates/placement-details/equipment.njk
@@ -19,7 +19,7 @@
 {{ super() }}
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
+    <section class="govuk-grid-column-three-quarters" aria-label="Form content">
         <span class="govuk-caption-xl">Placement details</span>
         <h1 class="govuk-heading-xl">
             {{ pageTitle }}
@@ -42,9 +42,9 @@
                 }) }}
             </div>
         </form>
-    </div>
-    <div class="govuk-grid-column-one-quarter">
-        {{ widgets(widgetData) }}
-    </div>
+    </section>
+
+    {{ widgets(widgetData) }}
+    
 </div>
 {% endblock %}

--- a/app/upw/templates/placement-details/intensive-working.njk
+++ b/app/upw/templates/placement-details/intensive-working.njk
@@ -19,7 +19,7 @@
 {{ super() }}
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
+    <section class="govuk-grid-column-three-quarters" aria-label="Form content">
         <span class="govuk-caption-xl">Placement details</span>
         <h1 class="govuk-heading-xl">
             {{ pageTitle }}
@@ -40,9 +40,9 @@
                 }) }}
             </div>
         </form>
-    </div>
-    <div class="govuk-grid-column-one-quarter">
-        {{ widgets(widgetData) }}
-    </div>
+    </section>
+
+    {{ widgets(widgetData) }}
+    
 </div>
 {% endblock %}

--- a/app/upw/templates/placement-restrictions/caring-commitments.njk
+++ b/app/upw/templates/placement-restrictions/caring-commitments.njk
@@ -19,7 +19,7 @@
 {{ super() }}
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
+    <section class="govuk-grid-column-three-quarters" aria-label="Form content">
         <span class="govuk-caption-xl">Placement restrictions due to health and other needs</span>
         <form method="post" action="{{ action }}">
             <input type="hidden" name="x-csrf-token" value="{{ csrfToken }}">
@@ -62,9 +62,9 @@
                 }) }}
             </div>
         </form>
-    </div>
-    <div class="govuk-grid-column-one-quarter">
-        {{ widgets(widgetData) }}
-    </div>
+    </section>
+
+    {{ widgets(widgetData) }}
+    
 </div>
 {% endblock %}

--- a/app/upw/templates/placement-restrictions/disabilities-and-mental-health.njk
+++ b/app/upw/templates/placement-restrictions/disabilities-and-mental-health.njk
@@ -21,7 +21,7 @@
 {{ super() }}
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
+    <section class="govuk-grid-column-three-quarters" aria-label="Form content">
         <span class="govuk-caption-xl">Placement restrictions due to health and other needs</span>
         <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
         
@@ -44,9 +44,9 @@
                 }) }}
             </div>
         </form>
-    </div>
-    <div class="govuk-grid-column-one-quarter">
-        {{ widgets(widgetData) }}
-    </div>
+    </section>
+
+    {{ widgets(widgetData) }}
+    
 </div>
 {% endblock %}

--- a/app/upw/templates/placement-restrictions/edit-gp-details.njk
+++ b/app/upw/templates/placement-restrictions/edit-gp-details.njk
@@ -30,7 +30,7 @@
 {% endif %}
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <section class="govuk-grid-column-two-thirds" aria-label="Form content">
         <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
         
         <form method="post" action="{{ action }}">
@@ -87,7 +87,6 @@
                 }) }}
             </div>
         </form>
-
-    </div>
+    </section>
 </div>
 {% endblock %}

--- a/app/upw/templates/placement-restrictions/gp-details.njk
+++ b/app/upw/templates/placement-restrictions/gp-details.njk
@@ -32,7 +32,7 @@
 
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
+    <section class="govuk-grid-column-three-quarters" aria-label="Form content">
         <span class="govuk-caption-xl">Placement restrictions due to health and other needs</span>
         <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
         
@@ -120,9 +120,9 @@
                 }) }}
             </div>
         </form>
-    </div>
-    <div class="govuk-grid-column-one-quarter">
-        {{ widgets(widgetData) }}
-    </div>
+    </section>
+
+    {{ widgets(widgetData) }}
+    
 </div>
 {% endblock %}

--- a/app/upw/templates/placement-restrictions/health-issues.njk
+++ b/app/upw/templates/placement-restrictions/health-issues.njk
@@ -19,7 +19,7 @@
 {{ super() }}
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
+    <section class="govuk-grid-column-three-quarters" aria-label="Form content">
         <span class="govuk-caption-xl">Placement restrictions due to health and other needs</span>
         <h1 class="govuk-heading-xl">Are there any other health issues that may affect ability to work?</h1>
         
@@ -43,9 +43,9 @@
                 }) }}
             </div>
         </form>
-    </div>
-    <div class="govuk-grid-column-one-quarter">
-        {{ widgets(widgetData) }}
-    </div>
+    </section>
+
+    {{ widgets(widgetData) }}
+    
 </div>
 {% endblock %}

--- a/app/upw/templates/placement-restrictions/travel-information.njk
+++ b/app/upw/templates/placement-restrictions/travel-information.njk
@@ -19,7 +19,7 @@
 {{ super() }}
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
+    <section class="govuk-grid-column-three-quarters" aria-label="Form content">
         <span class="govuk-caption-xl">Placement restrictions due to health and other needs</span>
         <h1 class="govuk-heading-xl">Travel information</h1>
         
@@ -39,9 +39,9 @@
                 }) }}
             </div>
         </form>
-    </div>
-    <div class="govuk-grid-column-one-quarter">
-        {{ widgets(widgetData) }}
-    </div>
+    </section>
+
+    {{ widgets(widgetData) }}
+    
 </div>
 {% endblock %}

--- a/app/upw/templates/risk-information/managing-risk.njk
+++ b/app/upw/templates/risk-information/managing-risk.njk
@@ -19,7 +19,7 @@
 {{ super() }}
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
+    <section class="govuk-grid-column-three-quarters" aria-label="Form content">
         <span class="govuk-caption-xl">Risk information</span>
         <h1 class="govuk-heading-xl">
             {{ pageTitle }}
@@ -47,9 +47,9 @@
                 }) }}
             </div>
         </form>
-    </div>
-    <div class="govuk-grid-column-one-quarter">
-        {{ widgets(widgetData) }}
-    </div>
+    </section>
+
+    {{ widgets(widgetData) }}
+    
 </div>
 {% endblock %}

--- a/app/upw/templates/risk-information/risk-of-harm-in-the-community.njk
+++ b/app/upw/templates/risk-information/risk-of-harm-in-the-community.njk
@@ -19,7 +19,7 @@
 {{ super() }}
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
+    <section class="govuk-grid-column-three-quarters" aria-label="Form content">
         <span class="govuk-caption-xl">Risk information</span>
         <h1 class="govuk-heading-xl">
             {{ pageTitle }}
@@ -47,9 +47,9 @@
                 }) }}
             </div>
         </form>
-    </div>
-    <div class="govuk-grid-column-one-quarter">
-        {{ widgets(widgetData) }}
-    </div>
+    </section>
+
+    {{ widgets(widgetData) }}
+    
 </div>
 {% endblock %}

--- a/app/upw/templates/taskList.njk
+++ b/app/upw/templates/taskList.njk
@@ -17,7 +17,7 @@
 {% block content %}
 {{ super() }}
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
+    <section class="govuk-grid-column-three-quarters" aria-label="Task list">
         <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
             {{ pageTitle }}
         </h1>
@@ -42,9 +42,9 @@
                 <a class="govuk-button govuk-button--secondary" href="{{ saveAssessmentUrl }}">Save and close</a>
             </form>
         </div>
-    </div>
-    <div class="govuk-grid-column-one-quarter">
-        {{ widgets(widgetData) }}
-    </div>
+    </section>
+    
+    {{ widgets(widgetData) }}
+    
 </div>
 {% endblock %}

--- a/common/templates/components/mappa-widget/template.njk
+++ b/common/templates/components/mappa-widget/template.njk
@@ -1,6 +1,6 @@
 {# Please ensure that any changes made here are also reflected in https://github.com/ministryofjustice/hmpps-risk-ui-elements #}
 
-<div class="mappa-widget">
+<aside class="mappa-widget" aria-label="MAPPA level">
 {% if mappa != null %}
     <h3 class="govuk-heading-m"><strong>{{ mappa.level | default("NO", true) }}</strong> MAPPA</h3>
     <p class="govuk-body-m">Multi-agency public protection arrangements</p>
@@ -14,4 +14,4 @@
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     <p class="govuk-body-m">Something went wrong. We are unable to show MAPPA information at this time. Try again later.</p>
 {% endif %}
-</div>
+</aside>

--- a/common/templates/components/risk-flag-widget/template.njk
+++ b/common/templates/components/risk-flag-widget/template.njk
@@ -1,9 +1,9 @@
-<div class="risk-flag-widget">
+<aside class="risk-flag-widget" aria-label="Delius risk flags">
     <h3 class="govuk-heading-m">Delius risk flags (registers)</h3>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     {% if flags != null %}
         {% if flags.length %}
-            <ul class="govuk-list">
+            <ul class="govuk-list" aria-label="Risk flags">
             {% for risk in flags %}
                 <li>{{ risk }}</li>
             {% endfor %}
@@ -14,4 +14,4 @@
     {% else %}
         <p>Something went wrong. We are unable to show risk flags at this time. Try again later.</p>
     {% endif %}
-</div>
+</aside>

--- a/common/templates/components/rosh-widget/template.njk
+++ b/common/templates/components/rosh-widget/template.njk
@@ -37,12 +37,13 @@
 {% endmacro %}
 
 {% if roshSummary and roshSummary.hasBeenCompleted %}
-  <div class="rosh-widget {{ getOverallRiskLevelClass(roshSummary.overallRisk) }}">
+  <aside class="rosh-widget {{ getOverallRiskLevelClass(roshSummary.overallRisk) }}" aria-label="Risk of serious harm summary">
     <h3 class="govuk-heading-m"><strong>{{ getRiskLevelText(roshSummary.overallRisk) | upper }}</strong> RoSH</h3>
     <p class="govuk-body-m">Risk of serious harm</p>
     <p class="govuk-hint govuk-body-m">Last updated: {{ roshSummary.lastUpdated | default("Not known") }}</p>
 
     <table class="govuk-table rosh-widget__table">
+      <caption class="govuk-visually-hidden">Risk of serious harm summary</caption>
       <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header">Risk to</th>
@@ -68,19 +69,19 @@
       </tr>
       </tbody>
     </table>
-  </div>
+  </aside>
   {% elif roshSummary and not roshSummary.hasBeenCompleted %}
-  <div class="rosh-widget rosh-widget--unknown">
+  <aside class="rosh-widget rosh-widget--unknown" aria-label="Risk of serious harm summary">
     <h3 class="govuk-heading-m"><strong>UNKNOWN LEVEL</strong> RoSH</h3>
     <p class="govuk-body-m">Risk of serious harm</p>
     <p class="govuk-hint govuk-body-m">A RoSH summary has not been completed for this individual. Check OASys for this
       person's current assessment status.</p>
   </div>
 {% else %}
-  <div class="rosh-widget">
+  <aside class="rosh-widget" aria-label="Risk of serious harm summary">
     <h3 class="govuk-heading-m"><strong>UNKNOWN LEVEL</strong> RoSH</h3>
     <p class="govuk-body-m">Risk of serious harm</p>
     <p class="govuk-hint govuk-body-m">Something went wrong. We are unable to show RoSH information at this time. Try
       again later.</p>
-  </div>
+  </aside>
 {% endif %}

--- a/common/templates/components/widgets/template.njk
+++ b/common/templates/components/widgets/template.njk
@@ -4,7 +4,9 @@
 {% from "common/templates/components/mappa-widget/macro.njk" import mappaWidget %}
 {% from "common/templates/components/risk-flag-widget/macro.njk" import riskFlagWidget %}
 
-<h3 class="govuk-heading-m">Risk information</h3>
-{{ roshWidget(params.roshRiskSummary) }}
-{{ mappaWidget(params.mappa) }}
-{{ riskFlagWidget(params.flags) }}
+<div class="govuk-grid-column-one-quarter">
+    <h2 class="govuk-heading-m">Risk information</h2>
+    {{ roshWidget(params.roshRiskSummary) }}
+    {{ mappaWidget(params.mappa) }}
+    {{ riskFlagWidget(params.flags) }}
+</div>

--- a/common/templates/partials/offenderDetails.njk
+++ b/common/templates/partials/offenderDetails.njk
@@ -15,7 +15,7 @@
     {% set offenderDetailsExists = true %}
   {% endif %}
   {% if offenderDetailsExists %}
-    <section class="key-details-bar" aria-label="Key details">
+    <aside class="key-details-bar" aria-label="Individuals key details">
       <div class="key-details-bar__top-block moj-context-header">
         <div class="column-reversed">
           <h2 class="key-details-bar__name"><span class="govuk-visually-hidden">Key details for </span>{{ subjectName }}</h2>
@@ -39,6 +39,6 @@
         </div>
         <hr class="key-details-bar__section-break govuk-section-break govuk-section-break--m govuk-section-break--visible">
       </div>
-    </section>
+    </aside>
   {% endif %}
 {% endif %}


### PR DESCRIPTION
Changes in this PR;

- The widgets and Individual's Details become `aside` elements with `aria-label`s, Voiceover will read these out as `<label> complimentary`
- The main form content has been moved to a `section` element, Voiceover will read this out as `Form content region`
- Use of `sections` and `aside` elements allows the user to quickly navigate between these regions using Voiceover
- Added a missing caption to the RoSH risk levels table
- Adjusted the heading elements used in the widgets section
- Added an `aria-label` to the Delius risk flags list, this provides additional context before the list is read out
