### PR TITLE
ARN-879 Update AppInsights initialisation to correctly send role name

### DIFF
--- a/common/assets/javascripts/app-insights.js
+++ b/common/assets/javascripts/app-insights.js
@@ -13,7 +13,7 @@
 window.appInsights = appInsights;
 
 appInsights.queue.push(function () {
-  appInsights.context.addTelemetryInitializer(function (envelope) {
+  appInsights.addTelemetryInitializer(function (envelope) {
     envelope.tags["ai.cloud.role"] = applicationInsightsRoleName;
   });
 });


### PR DESCRIPTION
Changes to the way custom properties are set up have changed in later version of the SDK but are not well documented - https://stackoverflow.com/questions/58238507/how-can-i-call-addtelemetryinitializer-when-using-the-latest-javascript-snippet gave insight to what needed changing. 