### PR TITLE
Initial fix for reflow issues on UPW availability page

### DIFF
--- a/app/error.njk
+++ b/app/error.njk
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="govuk-width-container govuk-width-container--app-extra-wide">
+<div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">

--- a/app/upw/templates/placement-details/availability.njk
+++ b/app/upw/templates/placement-details/availability.njk
@@ -32,7 +32,7 @@
   {%- endmacro -%}
 
   {%- macro availabilityOption(optionNumber) -%}
-    <td class="govuk-table__cell upw-availability-table__column upw-availability-table__item-{{ optionNumber }}">
+    <td class="govuk-table__cell upw-availability-table__cell upw-availability-table__item-{{ optionNumber }}">
       <div class="govuk-checkboxes__item govuk-checkboxes govuk-checkboxes--small upw-checkbox-item__availability">
         <input class="govuk-checkboxes__input" name="{{ questions['individual_availability'].questionCode }}"
                id="{{ questions['individual_availability'].questionCode }}-{{ optionNumber }}" name="organisation"

--- a/app/upw/templates/placement-details/availability.njk
+++ b/app/upw/templates/placement-details/availability.njk
@@ -56,7 +56,7 @@
       <form method="post" action="{{ action }}">
         <input type="hidden" name="x-csrf-token" value="{{ csrfToken }}">
 
-        <fieldset class="govuk-fieldset scrollable" aria-describedby="individual_availability-legend">
+        <fieldset class="govuk-fieldset" aria-describedby="individual_availability-legend">
           <table class="govuk-table upw-availability-table">
             <caption class="upw-availability-table__caption">
               <legend id="individual_availability-legend" class="govuk-fieldset__legend individual_availability govuk-label--m">

--- a/app/upw/templates/placement-details/availability.njk
+++ b/app/upw/templates/placement-details/availability.njk
@@ -56,7 +56,7 @@
       <form method="post" action="{{ action }}">
         <input type="hidden" name="x-csrf-token" value="{{ csrfToken }}">
 
-        <fieldset class="govuk-fieldset" aria-describedby="individual_availability-legend">
+        <fieldset class="govuk-fieldset scrollable" aria-describedby="individual_availability-legend">
           <table class="govuk-table upw-availability-table">
             <caption class="upw-availability-table__caption">
               <legend id="individual_availability-legend" class="govuk-fieldset__legend individual_availability govuk-label--m">

--- a/common/assets/sass/_upw-pages.scss
+++ b/common/assets/sass/_upw-pages.scss
@@ -89,46 +89,26 @@ $compact-table-breakpoint: 650px;
   width: 90px !important;
 }
 
-.upw-checkbox-item__availability {
-  @media (max-width: $compact-table-breakpoint) {
-    min-height: 0;
+.upw-availability-table__cell {
+  padding: 10px 24px 10px 0;
+  border-left: 1px solid #b1b4b6;
+  border-right: 1px solid #b1b4b6;
+
+  &:last-child {
+    padding: 10px 24px 10px 0;
   }
 
-  .govuk-checkboxes__label::before {
-    left: 38px;
-
-    @media (max-width: $compact-table-breakpoint) {
-      left: 0;
-      top: 0;
-      margin: 0 auto;
-    }
-  }
-
-  .govuk-checkboxes__label::after {
-    @media (min-width: $compact-table-breakpoint) {
-      left: 43px !important;
-    }
-
-    @media (max-width: $compact-table-breakpoint) {
-      left: 6px;
-      top: 7px;
-    }
+  .govuk-checkboxes__item {
+    padding: 0;
+    width: 0;
+    height: 0;
+    margin: 0 auto;
   }
 }
 
 .upw-availability-table__column {
   border-left: 1px solid #b1b4b6;
   border-right: 1px solid #b1b4b6;
-
-  @media (max-width: $compact-table-breakpoint) {
-    padding: 4px;
-  }
-
-  .govuk-checkboxes__item {
-    @media (max-width: $compact-table-breakpoint) {
-      padding: 4px;
-    }
-  }
 }
 
 .upw-availability-table__column > :last-child {

--- a/common/assets/sass/_upw-pages.scss
+++ b/common/assets/sass/_upw-pages.scss
@@ -24,13 +24,21 @@ $compact-table-breakpoint: 650px;
   float: left;
 }
 
-.upw-read-only__link {
-  font-size: 1.25rem;
+.upw-summary__links {
   float: right;
   margin-bottom: govuk-spacing(4);
+
+  & a {
+    font-size: 1.25rem;
+    margin-left: 10px;
+  }
+
+  & a:first-of-type {
+    margin-left: 0;
+  }
 }
 
-.upw-remove__link {
+.upw-summary__link--remove {
   color: #d4351c !important;
   margin-left: 10px;
 }

--- a/common/assets/sass/_upw-pages.scss
+++ b/common/assets/sass/_upw-pages.scss
@@ -1,6 +1,7 @@
 /*  styles related to specific questions and elements in the unpaid work assessment */
 @use "sass:math";
-@use "sass:map";
+
+$compact-table-breakpoint: 650px;
 
 /* stylelint-disable selector-class-pattern */
 .cultural_religious_adjustment,
@@ -60,7 +61,7 @@
   text-align: center;
   width: 90px;
 
-  @media (max-width: 650px) {
+  @media (max-width: $compact-table-breakpoint) {
     padding: 2px;
     writing-mode: vertical-rl;
     vertical-align: middle;
@@ -81,14 +82,14 @@
 }
 
 .upw-checkbox-item__availability {
-  @media (max-width: 650px) {
+  @media (max-width: $compact-table-breakpoint) {
     min-height: 0;
   }
 
   .govuk-checkboxes__label::before {
     left: 38px;
 
-    @media (max-width: 650px) {
+    @media (max-width: $compact-table-breakpoint) {
       left: 0;
       top: 0;
       margin: 0 auto;
@@ -96,11 +97,11 @@
   }
 
   .govuk-checkboxes__label::after {
-    @media (min-width: 650px) {
+    @media (min-width: $compact-table-breakpoint) {
       left: 43px !important;
     }
 
-    @media (max-width: 650px) {
+    @media (max-width: $compact-table-breakpoint) {
       left: 6px;
       top: 7px;
     }
@@ -111,12 +112,12 @@
   border-left: 1px solid #b1b4b6;
   border-right: 1px solid #b1b4b6;
 
-  @media (max-width: 650px) {
+  @media (max-width: $compact-table-breakpoint) {
     padding: 4px;
   }
 
   .govuk-checkboxes__item {
-    @media (max-width: 650px) {
+    @media (max-width: $compact-table-breakpoint) {
       padding: 4px;
     }
   }

--- a/common/assets/sass/_upw-pages.scss
+++ b/common/assets/sass/_upw-pages.scss
@@ -1,5 +1,6 @@
 /*  styles related to specific questions and elements in the unpaid work assessment */
 @use "sass:math";
+@use "sass:map";
 
 /* stylelint-disable selector-class-pattern */
 .cultural_religious_adjustment,
@@ -58,6 +59,13 @@
   line-height: 16px;
   text-align: center;
   width: 90px;
+
+  @media (max-width: 650px) {
+    padding: 2px;
+    writing-mode: vertical-rl;
+    vertical-align: middle;
+    text-orientation: sideways;
+  }
 }
 
 .upw-availability-table__rowheader {
@@ -73,18 +81,45 @@
 }
 
 .upw-checkbox-item__availability {
+  @media (max-width: 650px) {
+    min-height: 0;
+  }
+
   .govuk-checkboxes__label::before {
     left: 38px;
+
+    @media (max-width: 650px) {
+      left: 0;
+      top: 0;
+      margin: 0 auto;
+    }
   }
 
   .govuk-checkboxes__label::after {
-    left: 43px !important;
+    @media (min-width: 650px) {
+      left: 43px !important;
+    }
+
+    @media (max-width: 650px) {
+      left: 6px;
+      top: 7px;
+    }
   }
 }
 
 .upw-availability-table__column {
   border-left: 1px solid #b1b4b6;
   border-right: 1px solid #b1b4b6;
+
+  @media (max-width: 650px) {
+    padding: 4px;
+  }
+
+  .govuk-checkboxes__item {
+    @media (max-width: 650px) {
+      padding: 4px;
+    }
+  }
 }
 
 .upw-availability-table__column > :last-child {

--- a/common/assets/sass/application.scss
+++ b/common/assets/sass/application.scss
@@ -31,10 +31,6 @@ $white-transparent: rgb(255 255 255 / 25%);
   max-width: $govuk-page-width;
 }
 
-.scrollable {
-  overflow: scroll;
-}
-
 .key-details-bar {
   padding: 0 0 40px;
 }

--- a/common/assets/sass/application.scss
+++ b/common/assets/sass/application.scss
@@ -1,4 +1,10 @@
 $govuk-global-styles: true;
+$govuk-page-width: 1220px;
+$govuk-breakpoints: (
+  mobile:  390px,
+  tablet:  1024px,
+  desktop: 1024px
+);
 
 @import "govuk-frontend/govuk/all";
 @import "@ministryofjustice/frontend/moj/all";
@@ -21,8 +27,12 @@ $white-transparent: rgb(255 255 255 / 25%);
   padding-top: 30px;
 }
 
-.govuk-width-container--app-extra-wide {
-  max-width: 1220px;
+.use-govuk-page-width {
+  max-width: $govuk-page-width;
+}
+
+.scrollable {
+  overflow: scroll;
 }
 
 .key-details-bar {

--- a/common/templates/components/read-only/template.njk
+++ b/common/templates/components/read-only/template.njk
@@ -1,69 +1,75 @@
 {%- from "node_modules/govuk-frontend/govuk/components/summary-list/macro.njk" import govukSummaryList -%}
 
 {% if params.title %}
-<div class="upw-read-only__header">
+  <div class="upw-read-only__header">
     <h3 class="govuk-heading-m upw-read-only__heading">{{ params.title }}</h2>
-    {% if params.removeUrl %}
-        <a href="{{params.removeUrl}}" class="upw-remove__link govuk-link upw-read-only__link">
-            Remove<span class="govuk-visually-hidden"> {{params.title}}</span>
+    <div class="upw-summary__links">
+      {% if params.editUrl %}
+        <a href="{{params.editUrl}}">
+            Change<span class="govuk-visually-hidden">
+            {{params.title}}</span>
         </a>
-    {% endif %}
-    {% if params.editUrl %}
-        <a href="{{params.editUrl}}" class="govuk-link upw-read-only__link">
-            Change<span class="govuk-visually-hidden"> {{params.title}}</span>
+      {% endif %}
+      {% if params.removeUrl %}
+        <a href="{{params.removeUrl}}" class="upw-summary__link--remove">
+            Remove<span class="govuk-visually-hidden">
+            {{params.title}}</span>
         </a>
-    {% endif %}
-</div>
+      {% endif %}
+    </div>
+  </div>
 {% endif %}
 {% if params.rows %}
-{{ govukSummaryList({
+  {{ govukSummaryList({
     classes: "upw-summary-list--top-border upw-summary-list--bottom-margin",
     rows: params.rows
 }) }}
 {% elif params.field.key %}
-    {% set fieldValue = params.ifNotPresent | default("No data") %}
-    {% if params.ifValuePresent %}
-        {% if params.answers[params.field.key] %}{% set fieldValue = params.conditional.value  %}{% endif %}
-    {% elif params.answers[params.field.key] %}
-        {% set fieldValue = params.answers[params.field.key] %}
+  {% set fieldValue = params.ifNotPresent | default("No data") %}
+  {% if params.ifValuePresent %}
+    {% if params.answers[params.field.key] %}{% set fieldValue = params.conditional.value %}
     {% endif %}
-    {% if params.conditional.key and fieldValue == params.conditional.value %}
-        {% set conditionalFieldValue = "No details" %}
-        {% if params.answers[params.conditional.key] %}{% set conditionalFieldValue = params.answers[params.conditional.key] %}{% endif %}
-        {{ govukSummaryList({
-            classes: "upw-summary-list--top-border upw-summary-list--bottom-margin",
-            rows: [
-                {
-                    key: {
-                        text: params.field.text
-                    },
-                    value: {
-                        html: fieldValue
-                    }
-                },
-                {
-                    key: {
-                        text: params.conditional.text
-                    },
-                    value: {
-                        html: conditionalFieldValue
-                    }
-                }
-            ]
-        }) }}
-    {% else %}
-        {{ govukSummaryList({
-            classes: "upw-summary-list--top-border upw-summary-list--bottom-margin",
-            rows: [
-                {
-                    key: {
-                        text: params.field.text
-                    },
-                    value: {
-                        html: fieldValue
-                    }
-                }
-            ]
-        }) }}
+  {% elif params.answers[params.field.key] %}
+    {% set fieldValue = params.answers[params.field.key] %}
+  {% endif %}
+  {% if params.conditional.key and fieldValue == params.conditional.value %}
+    {% set conditionalFieldValue = "No details" %}
+    {% if params.answers[params.conditional.key] %}{% set conditionalFieldValue = params.answers[params.conditional.key] %}
     {% endif %}
+    {{ govukSummaryList({
+      classes: "upw-summary-list--top-border upw-summary-list--bottom-margin",
+      rows: [
+        {
+          key: {
+            text: params.field.text
+          },
+          value: {
+            html: fieldValue
+          }
+        },
+        {
+          key: {
+            text: params.conditional.text
+          },
+          value: {
+            html: conditionalFieldValue
+          }
+        }
+      ]
+    }) }}
+  {% else %}
+    {{ govukSummaryList({
+      classes: "upw-summary-list--top-border upw-summary-list--bottom-margin",
+      rows: [
+        {
+          key: {
+            text: params.field.text
+          },
+          value: {
+            html: fieldValue
+          }
+        }
+      ]
+    }) }}
+  {% endif %}
 {% endif %}

--- a/common/templates/components/read-only/template.njk
+++ b/common/templates/components/read-only/template.njk
@@ -2,7 +2,7 @@
 
 {% if params.title %}
 <div class="upw-read-only__header">
-    <h2 class="govuk-heading-m upw-read-only__heading">{{ params.title }}</h2>
+    <h3 class="govuk-heading-m upw-read-only__heading">{{ params.title }}</h2>
     {% if params.removeUrl %}
         <a href="{{params.removeUrl}}" class="upw-remove__link govuk-link upw-read-only__link">
             Remove<span class="govuk-visually-hidden"> {{params.title}}</span>

--- a/common/templates/layout.njk
+++ b/common/templates/layout.njk
@@ -5,8 +5,6 @@
 
 {% extends "govuk/template.njk" %}
 
-{% set containerClasses = "govuk-width-container--app-extra-wide" %}
-
 {% block bodyStart %}
   {% include "common/templates/includes/scripts.njk" %}
 {% endblock %}
@@ -52,13 +50,12 @@
 {% block footer %}
 
   <div class="govuk-!-display-none-print arn-white-background">
-    <div class="govuk-width-container {{ containerClasses }}">
+    <div class="govuk-width-container">
       {% include "../templates/components/feedbackBanner/feedbackBanner.njk" %}
     </div>
   </div>
 
-  {{ govukFooter({
-    containerClasses: containerClasses,
+  {{ govukFooter({    
     meta: {
       items: [
         {

--- a/common/templates/partials/header.njk
+++ b/common/templates/partials/header.njk
@@ -2,7 +2,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 <header class="moj-header" role="banner">
-  <div class="moj-header__container govuk-width-container--app-extra-wide">
+  <div class="moj-header__container use-govuk-page-width">
     <div class="moj-header__logo">
       {{ renderMojCrest('#FFFFFF', 40) }}
       <a class="moj-header__link moj-header__link--organisation-name" href="/">HMPPS</a>
@@ -32,7 +32,7 @@
   {% if usingBrowserBack %}
     {% set backLink = previousUrl %}
   {% endif %}
-  <div class="moj-primary-navigation__container govuk-width-container--app-extra-wide">
+  <div class="moj-primary-navigation__container use-govuk-page-width">
     <div role="navigation" aria-label="back">      
       <a id="back-link" href="{{ backLink }}" class="govuk-back-link">{{ backText | default("Back") }}</a>
     </div>


### PR DESCRIPTION
**Desktop -> Mobile reflow testing**

![availability-reflow](https://user-images.githubusercontent.com/20080441/183646957-e868aa6b-38b0-4000-88be-debf62a4b5ac.gif)

Due to us using a wide page container I've combined the `mobile` and `tablet`  breakpoints so that we can adjust for a non-desktop experience. It's likely we will want the reflow to happen when we're not at `desktop` resolutions.

The risk widgets on the right will move underneath the main contain when we go below the `desktop` breakpoint. I've put a few styling changes to try and avoid horizontal scrolling when we hit `mobile` resolutions.

Also updated the reflow behaviour for read-only data as part of this PR

![availability-reflow-2](https://user-images.githubusercontent.com/20080441/183648216-85b47cac-cffe-46de-83f1-b1b444a98b14.gif)
