### PR TITLE
ARN-1114 - Refactor controllers to limit answers local answers to current page

### DIFF
--- a/app/common/controllers/saveAndContinue.js
+++ b/app/common/controllers/saveAndContinue.js
@@ -71,9 +71,24 @@ class SaveAndContinue extends BaseController {
       })
 
     const submittedAnswers =
-      errorSummary.length === 0 ? req.sessionModel.get('answers') || {} : req.sessionModel.get('formAnswers') || {}
+      // errorSummary.length === 0 ? req.sessionModel.get('answers') || {} : req.sessionModel.get('formAnswers') || {}
+      req.sessionModel.get('formAnswers') || {}
 
-    const questionsWithMappedAnswers = questions.map(withAnswersFrom(previousAnswers, answerDtoFrom(submittedAnswers)))
+    const filterAnswers = (answers, fields) => {
+      return Object.entries(answers).reduce((acc, [answerCode, value]) => {
+        if (fields.filter((questionCode) => questionCode === answerCode).length > 0) {
+          return { ...acc, [answerCode]: value }
+        }
+
+        return acc
+      }, {})
+    }
+
+    const filteredSubmittedAnswers = filterAnswers(submittedAnswers, Object.keys(req.form.options.fields))
+
+    const questionsWithMappedAnswers = questions.map(
+      withAnswersFrom(previousAnswers, answerDtoFrom(filteredSubmittedAnswers)),
+    )
 
     const questionWithPreCompiledConditionals = compileConditionalQuestions(
       questionsWithMappedAnswers.filter((questionSchema) => req.form.options.fields[questionSchema.questionCode]),

--- a/app/common/controllers/saveAndContinue.test.js
+++ b/app/common/controllers/saveAndContinue.test.js
@@ -27,6 +27,8 @@ describe('SaveAndContinueController', () => {
           return values.errors || []
         case 'answers':
           return values.answers || {}
+        case 'formAnswers':
+          return values.formAnswers || {}
         case 'rawAnswers':
           return values.rawAnswers || {}
         default:
@@ -233,15 +235,25 @@ describe('SaveAndContinueController', () => {
         },
       }
 
-      mockSessionModel({
+      const allFields = {
+        ...fields,
+        fifth_question: {
+          questionCode: 'fifth_question',
+          answerType: 'numeric',
+          default: 'TEST',
+        },
+      }
+
+      getAnswers.mockResolvedValue({
         answers: {
-          first_question: 'FOO',
-          second_question: 'BAR',
+          first_question: ['FOO'],
+          second_question: ['BAR'],
+          fifth_question: ['BAZ'],
         },
       })
 
       req.form.options.fields = fields
-      req.form.options.allFields = fields
+      req.form.options.allFields = allFields
 
       await controller.locals(req, res, () => {})
 
@@ -287,7 +299,7 @@ describe('SaveAndContinueController', () => {
       }
 
       mockSessionModel({
-        answers: {
+        formAnswers: {
           first_question: 'SUBMITTED_FOO',
           second_question: '',
           third_question: '',

--- a/app/common/controllers/saveAndContinue.utils.js
+++ b/app/common/controllers/saveAndContinue.utils.js
@@ -64,7 +64,7 @@ const withAnswersFrom =
       const [selectedAnswer] = fieldProperties.answerDtos.filter((answer) => answer.value === checkedAnswer)
       const displayAnswer = selectedAnswer?.text || ''
 
-      if (fieldProperties.questionCode.match(/^\w+_complete$/)) {
+      if (fieldName.match(/^\w+_complete$/)) {
         if (checkedAnswer !== SECTION_COMPLETE) {
           checkedAnswer = SECTION_INCOMPLETE
         }

--- a/app/common/controllers/saveAndContinue.utils.test.js
+++ b/app/common/controllers/saveAndContinue.utils.test.js
@@ -1,0 +1,67 @@
+const { withAnswersFrom } = require('./saveAndContinue.utils')
+
+const fields = [
+  ['text-area-field', { questionCode: 'text-area-field', answerType: 'textarea' }],
+  [
+    'radio-field',
+    { questionCode: 'radio-field', answerType: 'radio', answerDtos: [{ value: 'YES' }, { value: 'NO' }] },
+  ],
+  ['text-field', { questionCode: 'text-field', answerType: 'freetext' }],
+]
+
+describe('withAnswersFrom', () => {
+  it('uses the answers from the API as base', () => {
+    const apiAnswers = {
+      'text-area-field': ['some value'],
+      'radio-field': ['YES'],
+      'text-field': [],
+    }
+
+    const localAnswers = {}
+
+    const updatedQuestions = fields.map(withAnswersFrom(apiAnswers, localAnswers))
+
+    expect(updatedQuestions).toEqual([
+      { questionCode: 'text-area-field', answerType: 'textarea', answer: 'some value' },
+      {
+        questionCode: 'radio-field',
+        answerType: 'radio',
+        answerDtos: [
+          { value: 'YES', checked: true },
+          { value: 'NO', checked: false },
+        ],
+        answer: '',
+      },
+      { questionCode: 'text-field', answerType: 'freetext', answer: '' },
+    ])
+  })
+
+  it('applies the submitted answers on top of the base', () => {
+    const apiAnswers = {
+      'text-area-field': ['some-value'],
+      'radio-field': ['YES'],
+      'text-field': [],
+    }
+
+    const localAnswers = {
+      'text-area-field': ['new submitted answer'],
+      'text-field': ['new submitted answer'],
+    }
+
+    const updatedQuestions = fields.map(withAnswersFrom(apiAnswers, localAnswers))
+
+    expect(updatedQuestions).toEqual([
+      { questionCode: 'text-area-field', answerType: 'textarea', answer: 'new submitted answer' },
+      {
+        questionCode: 'radio-field',
+        answerType: 'radio',
+        answerDtos: [
+          { value: 'YES', checked: true },
+          { value: 'NO', checked: false },
+        ],
+        answer: '',
+      },
+      { questionCode: 'text-field', answerType: 'freetext', answer: 'new submitted answer' },
+    ])
+  })
+})

--- a/app/upw/controllers/saveAndContinue.js
+++ b/app/upw/controllers/saveAndContinue.js
@@ -54,8 +54,8 @@ class SaveAndContinue extends BaseSaveAndContinue {
   }
 
   saveValues(req, res, next) {
-    const answers = req.sessionModel.get('formAnswers') || {}
-    req.sessionModel.set('answers', answers)
+    // const answers = req.sessionModel.get('formAnswers') || {}
+    // req.sessionModel.set('answers', answers)
 
     super.saveValues(req, res, next)
   }


### PR DESCRIPTION
This PR intends to limit the local answer cache to just the current page, this will ensure the up to date answers displayed to the user are reflective of what is persisted in the backend.

This does however "break" our local testing for this as we're not relying on the session model for answers and we don't currently persist anything in the backend with Wiremock. I'll look at fixing this in a follow up PR