### PR TITLE
Update UPW endpoint to set Content Disposition header in response

### DIFF
--- a/app/upw/controllers/api.js
+++ b/app/upw/controllers/api.js
@@ -42,7 +42,12 @@ const fetchTemplateData = async (episodeId) => {
 }
 
 const sendDocumentResponse = (res, document) =>
-  res.status(200).set('Content-Type', 'application/pdf').set('Content-Length', document.length).send(document)
+  res
+    .status(200)
+    .set('Content-Type', 'application/pdf')
+    .set('Content-Length', document.length)
+    .set('Content-Disposition', 'attachment; filename="upw-assessment.pdf"')
+    .send(document)
 
 const generatePdf = (res) => async (templateData) => {
   const rendered = nunjucks.render('app/upw/templates/pdf-preview-and-declaration/pdf.njk', {


### PR DESCRIPTION
Using a generic filename here as we would otherwise be required to hit several API endpoints. Given the context in which the file is displayed in Delius, this shouldn't be an issue