### PR TITLE
Fix error messages not showing for conditionals

### DIFF
--- a/app/common/controllers/saveAndContinue.utils.js
+++ b/app/common/controllers/saveAndContinue.utils.js
@@ -205,7 +205,18 @@ const answerDtoFrom = (formValues) =>
     }
   }, {})
 
-const renderConditionalQuestion = (questions, questionDto, conditionalQuestionCodes, errors, _nunjucks = nunjucks) => {
+const formatForNunjucks = (str = '') =>
+  str
+    .replace('{{', '{ {') // Prevent nunjucks mistaking the braces when rendering the template
+    .replace('}}', '} }')
+
+const renderConditionalQuestion = (
+  questions,
+  questionDto,
+  conditionalQuestionCodes,
+  errors = {},
+  _nunjucks = nunjucks,
+) => {
   const conditionalQuestions = conditionalQuestionCodes.map(({ code, deps }) => {
     const [schema] = questions.filter((question) => question.questionCode === code)
     return { schema, deps }
@@ -231,17 +242,12 @@ const renderConditionalQuestion = (questions, questionDto, conditionalQuestionCo
         )
       }
 
-      const validationError = errors[conditionalQuestionSchema.questionCode]
-
-      const questionString = JSON.stringify(conditionalQuestionSchema)
-        .replace('{{', '{ {') // Prevent nunjucks mistaking the braces when rendering the template
-        .replace('}}', '} }')
-
-      const errorString = validationError ? `, ${JSON.stringify(validationError)}` : ''
+      const questionString = formatForNunjucks(JSON.stringify(conditionalQuestionSchema))
+      const errorString = formatForNunjucks(JSON.stringify(errors))
 
       const conditionalQuestionString =
         '{% from "common/templates/components/question/macro.njk" import renderQuestion %} \n' +
-        `{{ renderQuestion(${questionString}${errorString}) }}`
+        `{{ renderQuestion(${questionString}, ${errorString}) }}`
 
       const renderedQuestion = _nunjucks.renderString(conditionalQuestionString).replace(/(\r\n|\n|\r)\s+/gm, '')
 

--- a/common/templates/components/question/template.njk
+++ b/common/templates/components/question/template.njk
@@ -61,7 +61,7 @@
 
 {# templates for each question type #}
 {% set questionAnswer = bodyAnswer or question.answer or '' %}
-{% set errorMessage = thisErrorMessage or errors[question.questionCode] %}
+{% set errorMessage = errors[question.questionCode] %}
 
 {% if question.type == 'group' %}
   <h2 class="govuk-heading-m">


### PR DESCRIPTION
Not sure how long this has been here, but looks like the wrong thing was being passed for validation errors on conditional questions

We would display the summary up top, but the inline error was missing