### PR TITLE
Remove PDF download button

### DIFF
--- a/app/upw/templates/confirmation.njk
+++ b/app/upw/templates/confirmation.njk
@@ -31,10 +31,6 @@
             Please follow the process that has been established in your region to let the unpaid work team know this assessment has been completed. This will enable the unpaid work induction to be arranged and for the person on probation to start their placement.
         </p>
 
-        <div class="govuk-button-group">
-            <a class="govuk-button" href="/UPW/pdf-download" download>Download the PDF</a>
-        </div>
-
         <div class="govuk-body">
         <a href="{{ feedbackUrl }}" class="govuk-link" target="_blank" rel="noopener noreferrer">
         What did you think of the service?</a>


### PR DESCRIPTION
Removing the PDF download button, this no longer has an endpoint in UPW and can be downloaded in Delius