### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@6
+  hmpps: ministryofjustice/hmpps@7
   slack: circleci/slack@4.4.2
 
 parameters:

--- a/helm_deploy/hmpps-risk-assessment-ui/Chart.yaml
+++ b/helm_deploy/hmpps-risk-assessment-ui/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
   - name: gotenberg
     version: 0.1.0
   - name: generic-service
-    version: 2.8.1
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.3

--- a/helm_deploy/hmpps-risk-assessment-ui/values.yaml
+++ b/helm_deploy/hmpps-risk-assessment-ui/values.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
   nameOverride: hmpps-risk-assessment-ui
 
@@ -8,14 +7,14 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/hmpps-risk-assessment-ui
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 3000
 
   ingress:
     enabled: true
     v1_2_enabled: true
     v0_47_enabled: false
-    host: app-hostname.local    # override per environment
+    host: app-hostname.local # override per environment
     tlsSecretName: hmpps-assessments-cert
 
   livenessProbe:
@@ -68,18 +67,12 @@ generic-service:
       SNS_TOPIC_ARN: "topic_arn"
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
     capita-vpn-1: 82.203.33.128/28
     capita-vpn-2: 82.203.33.112/28
-    ark-internet-1: "194.33.192.0/25"
-    ark-internet-2: "194.33.196.0/25"    
+    ark-nps-hmcts-ttp2: 194.33.192.0/25
+    ark-nps-hmcts-ttp4: 194.33.196.0/25
+    groups:
+      - internal
 
 generic-prometheus-alerts:
   targetApplication: hmpps-risk-assessment-ui


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

1 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/hmpps-risk-assessment-ui/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal`
- The size of the allowlist defined in this file will change: `12 => 4 (8 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  
