### PR TITLE
Re-enable access from internal services

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -20,6 +20,7 @@ generic-service:
 
   allowlist:
     groups:
+      - internal
       - probation
 
 generic-prometheus-alerts:


### PR DESCRIPTION
Fixes https://ministryofjustice.sentry.io/issues/5168685631

Note: this is currently blocking UPW assessment documents from being uploaded into Delius, since yesterday.